### PR TITLE
feat: add header & footer support on release notes page

### DIFF
--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -1,5 +1,16 @@
 import React from 'react';
+import { StudioFooterSlot } from '@edx/frontend-component-footer';
 
-const ReleaseNotes = () => <h1>Welcome to release-notes!</h1>;
+import Header from '../header';
+
+const ReleaseNotes = () => (
+  <>
+    <Header isHiddenMainMenu />
+    <main className="page-content">
+      <h1>Welcome to release-notes!</h1>
+    </main>
+    <StudioFooterSlot />
+  </>
+);
 
 export default ReleaseNotes;


### PR DESCRIPTION
**Before:**
<img width="1792" height="1074" alt="Screenshot 2025-10-07 at 12 14 47 PM" src="https://github.com/user-attachments/assets/5188db70-eece-4ecf-9bf1-8c947bfb2017" />

**After:**
<img width="1792" height="1074" alt="Screenshot 2025-10-07 at 12 14 14 PM" src="https://github.com/user-attachments/assets/e007b40d-7e90-4121-9232-dc2f12bf7743" />
