### PR TITLE
fix: release-notes page UI fixes

### DIFF
--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -228,8 +228,8 @@ const ReleaseNotes = () => {
               </Layout.Element>
             </Layout>
           ) : (
-            <div className="text-center py-5">
-              <span className="small">{intl.formatMessage(messages.noReleaseNotes)}</span>
+            <div className="text-center py-5 d-flex justify-content-center align-items-center no-release-notes-container">
+              <span className="medium">{intl.formatMessage(messages.noReleaseNotes)}</span>
             </div>
           )
         )}

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -31,10 +31,6 @@
     }
 }
 
-.release-notes-page-content {
-    min-height: 780px;
-}
-
 .release-notes-sidebar {
     .font-weight-bold {
         font-weight: 700;
@@ -59,13 +55,17 @@
         color: var(--pgn-color-black);
     }
 
-    .sub-header {
-        border-bottom: 2px solid black;
+    > div:first-child {
+        border-bottom: 2px solid black !important;
     }
 
     .pgn__icon {
         max-width: 20px !important;
         max-height: 20px !important;
+    }
+
+    .row {
+        min-height: 675px;
     }
 }
 
@@ -167,4 +167,8 @@
 
 .pgn__modal.pgn__modal-xl.pgn__modal-default {
     max-height: unset;
+}
+
+.no-release-notes-container {
+    min-height: 675px;
 }


### PR DESCRIPTION
- fix border bottom for `Release-notes for edX` heading, it was showing 2 lines, 1 dark and 1 light border bottom line.
- fix minimum height for the release notes container when there are no posts or the posts are smaller than normal page height and move the statement to the center of the page.

**Before:**
<video src="https://github.com/user-attachments/assets/f4633b69-f699-4650-b418-06640bf134c5" controls></video>
<img width="1792" height="1074" alt="Screenshot 2025-10-27 at 5 32 26 PM" src="https://github.com/user-attachments/assets/209ce65f-12aa-47a7-bcf9-e752593f5212" />

**After:**
<video src="https://github.com/user-attachments/assets/4ee0eee8-972a-42fd-aba5-06c86fd3bb85" controls></video>
<img width="1792" height="1074" alt="Screenshot 2025-10-27 at 5 30 46 PM" src="https://github.com/user-attachments/assets/5b4b3b99-35ab-4132-b115-363315640613" />

