### PR TITLE
fix: keep actual image size instead of 100% width

### DIFF
--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -92,7 +92,6 @@
         align-self: flex-start;
     }
 
-    img,
     video,
     iframe {
         width: 100%;


### PR DESCRIPTION
Fix image size bug as it wasn't retaining actual image size. in this PR, keep actual image size instead of 100% width.

**Before:**
<video src="https://github.com/user-attachments/assets/eb475e48-f1be-47b2-85da-3e64e62ba8e9" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/64cd484c-4b68-40a4-97e0-cf8c320054d3" controls></video>

