### PR TITLE
fix: restrict single select questions to one correct answer

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -90,7 +90,7 @@ export const useFeedback = (answer) => {
 };
 
 export const isSingleAnswerProblem = (problemType) => (
-  problemType === ProblemTypeKeys.DROPDOWN
+  problemType === ProblemTypeKeys.SINGLESELECT || problemType === ProblemTypeKeys.DROPDOWN
 );
 
 export const useAnswerContainer = ({ answers, updateField }) => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -200,7 +200,7 @@ describe('Answer Options Hooks', () => {
   });
   describe('isSingleAnswerProblem()', () => {
     test('singleSelect', () => {
-      expect(module.isSingleAnswerProblem(ProblemTypeKeys.SINGLESELECT)).toBe(false);
+      expect(module.isSingleAnswerProblem(ProblemTypeKeys.SINGLESELECT)).toBe(true);
     });
     test('multiSelect', () => {
       expect(module.isSingleAnswerProblem(ProblemTypeKeys.MULTISELECT)).toBe(false);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -299,9 +299,9 @@ export const typeRowHooks = ({
     if (typeKey === ProblemTypeKeys.TEXTINPUT && RichTextProblems.includes(problemType)) {
       convertToPlainText();
     }
-    // Dropdown problems can only have one correct answer. When there is more than one correct answer
+    // Dropdown and single-select problems can only have one correct answer. When there is more than one correct answer
     // from a previous problem type, the correct attribute for selected answers need to be set to false.
-    if (typeKey === ProblemTypeKeys.DROPDOWN) {
+    if (typeKey === ProblemTypeKeys.DROPDOWN || typeKey === ProblemTypeKeys.SINGLESELECT) {
       if (correctAnswerCount > 1) {
         clearPreviouslySelectedAnswers();
       } else if (RichTextProblems.includes(problemType)) {


### PR DESCRIPTION
## Description

This fix ensures that single select question types only allow one correct answer.
Previously, Studio incorrectly allowed multiple correct answers to be selected for single select questions. The logic has been updated to properly treat SINGLESELECT as a single-answer problem type.

### Jira
- [TNL2-402 ](https://2u-internal.atlassian.net/browse/TNL2-402)

### Before

<img width="1003" height="876" alt="image (6)" src="https://github.com/user-attachments/assets/1c385212-d2a5-43eb-b23f-33644574ae4b" />


### After 

<img width="1017" height="869" alt="image (5)" src="https://github.com/user-attachments/assets/2ce6488a-ec0b-455e-90de-3ede0758a50a" />


### Single select problem demo video

https://github.com/user-attachments/assets/f013e8a6-de58-4ebf-90a2-e65d2253755b

