### PR TITLE
Fix/release notes fixes

### DIFF
--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -186,7 +186,7 @@ const ReleaseNotes = () => {
                                   >
                                     <button
                                       type="button"
-                                      className="btn-link d-inline-flex align-items-center text-muted small mr-2 p-0 border-0 text-decoration-none"
+                                      className="btn-link d-inline-flex align-items-center text-muted small mr-2 p-0 border-0 text-decoration-none bg-transparent"
                                       aria-label={intl.formatMessage(messages.scheduledTooltip, {
                                         date: `${moment(post.published_at).format('MMMM D, YYYY h:mm A')} ${getTzName(new Date(post.published_at))}`,
                                       })}

--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -134,22 +134,25 @@ const ReleaseNotes = () => {
         </Container>
       )}
       <Container size="xl" className="release-notes-page px-4 pt-4">
-        <SubHeader
-          title={intl.formatMessage(messages.headingTitle)}
-          subtitle=""
-          instruction=""
-          headerActions={administrator && !errors.loadingNotes ? (
-            <Button
-              variant="primary"
-              iconBefore={AddIcon}
-              size="sm"
-              className="new-post-button"
-              onClick={() => handleOpenUpdateForm(REQUEST_TYPES.add_new_update)}
-            >
-              {intl.formatMessage(messages.newPostButton)}
-            </Button>
-          ) : null}
-        />
+        <div className="py-5">
+          <SubHeader
+            title={intl.formatMessage(messages.headingTitle)}
+            subtitle=""
+            instruction=""
+            hideBorder
+            headerActions={administrator && !errors.loadingNotes ? (
+              <Button
+                variant="primary"
+                iconBefore={AddIcon}
+                size="sm"
+                className="new-post-button"
+                onClick={() => handleOpenUpdateForm(REQUEST_TYPES.add_new_update)}
+              >
+                {intl.formatMessage(messages.newPostButton)}
+              </Button>
+            ) : null}
+          />
+        </div>
 
         {!errors.loadingNotes && (
           groups.length > 0 ? (

--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -166,7 +166,7 @@ const ReleaseNotes = () => {
                   <section className="release-notes-list pt-5">
                     {groups.map((g) => (
                       <div key={g.key} className="mb-4" id={`note-group-${g.key}`}>
-                        <h2 className="mb-4.5 pb-4.5">
+                        <h2 className="mb-4.5 pb-4.5 group-title">
                           {g.label}
                         </h2>
                         {g.items.map((post) => (
@@ -203,7 +203,7 @@ const ReleaseNotes = () => {
                                   </OverlayTrigger>
                                 )}
                                 <div className="d-flex align-items-center mb-1 justify-content-between">
-                                  <h3 className="m-0">{post.title}</h3>
+                                  <h3 className="m-0 post-title">{post.title}</h3>
                                   {administrator && (
                                     <div className="ml-3 d-flex">
                                       <IconButtonWithTooltip

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -186,6 +186,7 @@
     line-height: 0;
     font-size: 14px;
     margin-top: 4px;
+    font-family: monospace;
 }
 
 .tooltip.scheduled-tooltip .tooltip-inner {

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -39,6 +39,10 @@
     max-width: 320px;
     margin-left: auto;
 
+    a {
+        font-size: 12px;
+    }
+
     .font-weight-bold {
         font-weight: 700;
     }
@@ -177,6 +181,10 @@
 
 .delete-notes-hover:hover {
     background-color: #D3D3D3;
+}
+
+.group-title {
+    font-size: 32px;
 }
 
 .post-title {

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -80,6 +80,7 @@
 
     .row {
         min-height: 675px;
+
         & > div:first-child {
             padding-right: 52px; // base padding 12px for left + 40px + right col left padding 12px = 64px
         }

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -36,7 +36,8 @@
     top: 0;
     height: 100vh;
     overflow-y: auto;
-    width: 320px;
+    max-width: 320px;
+    margin-left: auto;
 
     .font-weight-bold {
         font-weight: 700;
@@ -79,6 +80,19 @@
 
     .row {
         min-height: 675px;
+        & > div:first-child {
+            padding-right: 52px; // base padding 12px for left + 40px + right col left padding 12px = 64px
+        }
+    }
+}
+
+@media screen and (width <= 1200px) {
+    .release-notes-page {
+        .row {
+            & > div:first-child {
+                padding-right: 0;
+            }
+        }
     }
 }
 

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -36,8 +36,6 @@
     top: 0;
     height: 100vh;
     overflow-y: auto;
-    max-width: 320px;
-    margin-left: auto;
 
     a {
         font-size: 12px;

--- a/src/release-notes/update-form/ReleaseNoteForm.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.jsx
@@ -337,7 +337,7 @@ const ReleaseNoteForm = ({
                   {intl.formatMessage(messages.cancelButton)}
                 </Button>
                 <StatefulButton
-                  variant="danger"
+                  variant="primary"
                   onClick={handleSubmit}
                   type="submit"
                   state={buttonState}


### PR DESCRIPTION
Sidebar font size change - https://2u-internal.atlassian.net/browse/TNL2-432
<img width="1791" height="626" alt="image" src="https://github.com/user-attachments/assets/9f41811f-2cc2-43fb-88a8-3676b545b9ec" />

---
Sidebar gap to 64px - https://2u-internal.atlassian.net/browse/TNL2-433
<img width="3582" height="1346" alt="image" src="https://github.com/user-attachments/assets/a68a2dec-b37f-4844-87dd-5fc55f71c206" />

---
Padding for header - https://2u-internal.atlassian.net/browse/TNL2-438
<img width="3582" height="1346" alt="image" src="https://github.com/user-attachments/assets/e48b8dcf-d133-4569-af01-cf8b82ba17a9" />

---
New post save button should be primary instead of danger - https://2u-internal.atlassian.net/browse/TNL2-441
<img width="1140" height="545" alt="image" src="https://github.com/user-attachments/assets/5845b2e4-8c89-4ff5-9473-8a82b32761df" />

---
- group title font size fix: Date as Group header
- Scheduled bg color to transparent and font to monospace

