### PR TITLE
fix: change background color for whole page

### DIFF
--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -124,7 +124,7 @@ const ReleaseNotes = () => {
   }, []);
 
   return (
-    <>
+    <div className="release-notes-page-wrapper">
       <Header isHiddenMainMenu />
       {errors.loadingNotes && (
         <Container size="xl" className="px-4 pt-4">
@@ -310,7 +310,7 @@ const ReleaseNotes = () => {
         </ModalDialog>
       )}
       <StudioFooterSlot />
-    </>
+    </div>
   );
 };
 

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -31,6 +31,10 @@
     }
 }
 
+.release-notes-page-wrapper {
+    background: #F3F3F3;
+}
+
 .release-notes-sidebar {
     position: sticky;
     top: 0;


### PR DESCRIPTION
Ticket: [TNL2-442](https://2u-internal.atlassian.net/browse/TNL2-442)
Change background color for whole page to `#F3F3F3`

**Before:**
<img width="1792" height="1078" alt="Screenshot 2025-11-14 at 3 32 33 PM" src="https://github.com/user-attachments/assets/87f0b41b-188f-4783-a8c2-aa847d039eb7" />


**After:**
<img width="1792" height="1078" alt="Screenshot 2025-11-14 at 3 30 48 PM" src="https://github.com/user-attachments/assets/cb37c6c7-1962-4b1b-b5b5-90c343aed90f" />
