### PR TITLE
chore: hide legacy library migration alert

### DIFF
--- a/src/studio-home/tabs-section/TabsSection.test.tsx
+++ b/src/studio-home/tabs-section/TabsSection.test.tsx
@@ -392,31 +392,6 @@ describe('<TabsSection />', () => {
       ).toBeVisible();
     });
 
-    it('should open migration library page from v1 libraries tab', async () => {
-      await axiosMock.onGet(getStudioHomeApiUrl()).reply(200, generateGetStudioHomeDataApiResponse());
-      await axiosMock.onGet(libraryApiLink).reply(200, generateGetStudioHomeLibrariesApiResponse());
-      render({ librariesV2Enabled: false });
-      const user = userEvent.setup();
-      await act(async () => executeThunk(fetchStudioHomeData(), store.dispatch));
-
-      // Libraries v2 tab should not be shown
-      expect(screen.queryByRole('tab', { name: librariesBetaTabTitle })).toBeNull();
-
-      const librariesTab = await screen.findByRole('tab', { name: tabMessages.librariesTabTitle.defaultMessage });
-      await user.click(librariesTab);
-
-      expect(librariesTab).toHaveClass('active');
-
-      expect(await screen.findByText(studioHomeMock.libraries[0].displayName)).toBeVisible();
-
-      const migratorButton = screen.getByRole('button', { name: /review legacy libraries/i });
-      expect(migratorButton).toBeInTheDocument();
-      await user.click(migratorButton);
-
-      const locationDisplay = await screen.findByTestId('location-display');
-      expect(locationDisplay).toHaveTextContent('/migrate');
-    });
-
     it('should open migration library page from v2 libraries tab', async () => {
       const libraries = generateGetStudioHomeLibrariesApiResponse().libraries.map(
         library => ({

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -125,6 +125,7 @@ const TabsSection = ({
           <LibrariesList
             migrationFilter={migrationFilter}
             setMigrationFilter={setMigrationFilter}
+            hideMigationAlert
           />
         </Tab>,
       );


### PR DESCRIPTION
**Before:**
<img width="1792" height="1075" alt="Screenshot 2025-11-14 at 6 41 54 PM" src="https://github.com/user-attachments/assets/b7585062-df5a-450c-9339-84df1496fef1" />

**After:**
<img width="1792" height="1075" alt="Screenshot 2025-11-14 at 6 41 26 PM" src="https://github.com/user-attachments/assets/e456ba00-43f9-4791-9ddb-9e4481cacba9" />
