### PR TITLE
feat: add font import from brand npm package

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,6 @@
 @use "@openedx/paragon/styles/css/core/custom-media-breakpoints.css" as paragonCustomMediaBreakpoints;
 
+@import "~@edx/brand/paragon/fonts";
 @import "~@edx/frontend-component-header/dist/index";
 @import "assets/scss/variables";
 @import "assets/scss/form";

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -197,7 +197,7 @@
     line-height: 0;
     font-size: 14px;
     margin-top: 4px;
-    font-family: monospace;
+    font-family: var(--pgn-typography-font-family-monospace);
 }
 
 .tooltip.scheduled-tooltip .tooltip-inner {


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/TNL2-439

Adding Inter font as its not being fetched for frontend-app-authoring mfe

Before:
<img width="428" height="174" alt="image" src="https://github.com/user-attachments/assets/fa479a01-f1d2-4d60-9908-db393457ebd7" />


After:
<img width="428" height="174" alt="image" src="https://github.com/user-attachments/assets/e29667f2-1228-4d13-abba-0ce6f82f3dee" />

