### PR TITLE
fix: restrict adding PDFs url form other origins

### DIFF
--- a/src/textbooks/textbook-card/TextbooksCard.test.jsx
+++ b/src/textbooks/textbook-card/TextbooksCard.test.jsx
@@ -117,7 +117,7 @@ describe('<TextbookCard />', () => {
       chapters: [
         {
           title: 'Chapter',
-          url: 'Url',
+          url: '/static/example.pdf',
         },
       ],
       id: textbooksMock.textbooks[1].id,

--- a/src/textbooks/textbook-form/TextbookForm.test.jsx
+++ b/src/textbooks/textbook-form/TextbookForm.test.jsx
@@ -98,7 +98,7 @@ describe('<TextbookForm />', () => {
       chapters: [
         {
           title: 'Chapter',
-          url: 'Url',
+          url: '/static/example.pdf',
         },
       ],
     };

--- a/src/textbooks/textbook-form/messages.js
+++ b/src/textbooks/textbook-form/messages.js
@@ -59,6 +59,11 @@ const descriptions = {
     defaultMessage: 'Chapter asset is required',
     description: 'Validation error message for the chapter asset field in the form',
   },
+  chapterUrlMustStartWithSlash: {
+    id: 'course-authoring.textbooks.form.chapter.url.must-start-with-slash',
+    defaultMessage: 'Chapter asset must start with a single forward slash (/) and cannot be an absolute URL. Try uploading the PDF.',
+    description: 'Validation error message for the chapter asset field in the form when the URL format is incorrect',
+  },
   addChapterHelperText: {
     id: 'course-authoring.textbooks.form.add-chapter.helper-text',
     defaultMessage: 'Please add at least one chapter',

--- a/src/textbooks/textbook-form/validations.js
+++ b/src/textbooks/textbook-form/validations.js
@@ -7,7 +7,19 @@ const textbookFormValidationSchema = (intl) => Yup.object().shape({
   chapters: Yup.array().of(
     Yup.object({
       title: Yup.string().required((intl.formatMessage(messages.chapterTitleValidationText))).max(255),
-      url: Yup.string().required(intl.formatMessage(messages.chapterUrlValidationText)).max(255),
+      url: Yup.string()
+        .required(intl.formatMessage(messages.chapterUrlValidationText))
+        .max(255)
+        .test(
+          'path-format',
+          intl.formatMessage(messages.chapterUrlMustStartWithSlash),
+          (value) => {
+            if (!value) { return false; }
+            return value.startsWith('/') // must start with single /
+              && !value.startsWith('//') // disallow //
+              && !/^https?:/i.test(value); // disallow absolute http/https
+          },
+        ),
     }),
   ).min(1),
 });


### PR DESCRIPTION
Ticket: [TNL2-452](https://2u-internal.atlassian.net/browse/TNL2-452)
Related edx-platform PR: https://github.com/edx/edx-platform/pull/51
**Before:**
<video src="https://github.com/user-attachments/assets/13247a7a-fb15-4a0d-9a44-a0656eeb803e" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/89caa64d-0dee-43fa-99fb-9d6063632973" controls></video>

