### PR TITLE
fix: center margin for studio-home component

### DIFF
--- a/src/studio-home/scss/StudioHome.scss
+++ b/src/studio-home/scss/StudioHome.scss
@@ -1,5 +1,5 @@
 .studio-home {
-  margin: 3rem 1.5rem 1.5rem;
+  margin: 3rem auto 1.5rem;
   min-height: 80vh;
 
   .help-sidebar {


### PR DESCRIPTION
## Description

Center aligning the main div for studio home, right now it is left aligned with just a small amount of padding.

## Supporting information

<img width="1686" height="705" alt="image" src="https://github.com/user-attachments/assets/98543007-a11a-4bef-a671-3f9f36d171c6" />

<img width="1686" height="707" alt="image" src="https://github.com/user-attachments/assets/f0f07c48-08e5-4395-b7a9-0d2cb0783de8" />

