### PR TITLE
fix: Content Group Creation Error in Studio

### DIFF
--- a/src/group-configurations/index.jsx
+++ b/src/group-configurations/index.jsx
@@ -60,9 +60,10 @@ const GroupConfigurations = ({ courseId }) => {
   }
 
   const enrollmentTrackGroup = shouldShowEnrollmentTrack
-    ? allGroupConfigurations[0]
+    ? allGroupConfigurations.find((config) => config.scheme === 'enrollment_track')
     : null;
-  const contentGroup = allGroupConfigurations?.[shouldShowEnrollmentTrack ? 1 : 0];
+  const contentTypeGateGroup = allGroupConfigurations?.find((config) => config.scheme === 'content_type_gate');
+  const contentGroup = allGroupConfigurations?.find((config) => config.scheme === 'cohort');
 
   return (
     <>
@@ -87,6 +88,11 @@ const GroupConfigurations = ({ courseId }) => {
               {!!enrollmentTrackGroup && (
                 <EnrollmentTrackGroupsSection
                   availableGroup={enrollmentTrackGroup}
+                />
+              )}
+              {!!contentTypeGateGroup && (
+                <EnrollmentTrackGroupsSection
+                  availableGroup={contentTypeGateGroup}
                 />
               )}
               {!!contentGroup && (

--- a/src/group-configurations/index.jsx
+++ b/src/group-configurations/index.jsx
@@ -60,7 +60,7 @@ const GroupConfigurations = ({ courseId }) => {
   }
 
   const enrollmentTrackGroup = shouldShowEnrollmentTrack
-    ? allGroupConfigurations.find((config) => config.scheme === 'enrollment_track')
+    ? allGroupConfigurations?.find((config) => config.scheme === 'enrollment_track')
     : null;
   const contentTypeGateGroup = allGroupConfigurations?.find((config) => config.scheme === 'content_type_gate');
   const contentGroup = allGroupConfigurations?.find((config) => config.scheme === 'cohort');


### PR DESCRIPTION
**Description**

- This PR fixes an issue where creating multiple content groups for cohorts in Studio was failing with the error:

_Studio’s having trouble saving your work. Unable to load this type of group configuration._

**What was fixed**

- Corrected a logical issue in the content group creation flow.
- Restored the behavior to match the legacy (non-MFE) page, where content group creation worked correctly.
- Authors can now create multiple content groups for cohorts without errors.
- Removed `contentGroupActions` for content-type gated groups in feature-based enrollment, as they are read-only and the actions were non-functional, aligning the behavior with legacy. (edit and delete options)

**Testing**

- Verified creating multiple content groups works as expected.

**Impact**
- Content group creation for cohorts is now fully functional across all courses.

**Legacy View (Reference) (Working as Expected)**

https://github.com/user-attachments/assets/120cde80-6fe7-4617-b81e-f087b4c992ac

**MFE View – Before Fix**

https://github.com/user-attachments/assets/4ce77c04-cb60-41a6-97c3-0580b575d0b0
 
**MFE View – After Fix**

https://github.com/user-attachments/assets/6e537461-7cbf-499f-8113-d96e13e66f8b

**Jira**
 [TNL2-421](https://2u-internal.atlassian.net/browse/TNL2-421)