### PR TITLE
feat: handle release notes CRUD actions with waffle flag

### DIFF
--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -16,7 +16,6 @@ import {
 } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import moment from 'moment';
-import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import Header from '../header';
 import SubHeader from '../generic/sub-header/SubHeader';
 import messages from './messages';
@@ -30,13 +29,13 @@ import unsavedMessages from './update-form/unsaved-modal-messages';
 
 const ReleaseNotes = () => {
   const intl = useIntl();
-  const { administrator } = getAuthenticatedUser() || {};
   const isDirtyCheckRef = React.useRef(() => false);
   const showUnsavedModalRef = React.useRef(null);
   const [isUnsavedModalOpen, setIsUnsavedModalOpen] = React.useState(false);
   const {
     requestType,
     notes,
+    hasAccess,
     notesInitialValues,
     isFormOpen,
     isDeleteModalOpen,
@@ -140,7 +139,7 @@ const ReleaseNotes = () => {
             subtitle=""
             instruction=""
             hideBorder
-            headerActions={administrator && !errors.loadingNotes ? (
+            headerActions={hasAccess && !errors.loadingNotes ? (
               <Button
                 variant="primary"
                 iconBefore={AddIcon}
@@ -204,7 +203,7 @@ const ReleaseNotes = () => {
                                 )}
                                 <div className="d-flex align-items-center mb-1 justify-content-between">
                                   <h3 className="m-0 post-title">{post.title}</h3>
-                                  {administrator && (
+                                  {hasAccess && (
                                     <div className="ml-3 d-flex">
                                       <IconButtonWithTooltip
                                         tooltipContent={intl.formatMessage(messages.editButton)}

--- a/src/release-notes/ReleaseNotes.test.jsx
+++ b/src/release-notes/ReleaseNotes.test.jsx
@@ -21,6 +21,7 @@ jest.mock('@edx/frontend-platform/auth', () => ({
 const mockUseReleaseNotes = {
   requestType: null,
   notes: [],
+  hasAccess: false,
   notesInitialValues: {},
   isFormOpen: false,
   isDeleteModalOpen: false,
@@ -138,6 +139,10 @@ describe('ReleaseNotes', () => {
 
     test('renders New Post button for admin users', () => {
       getAuthenticatedUser.mockReturnValue({ administrator: true });
+      useReleaseNotes.mockReturnValue({
+        ...mockUseReleaseNotes,
+        hasAccess: true,
+      });
       renderReleaseNotes();
       expect(screen.getByRole('button', { name: messages.newPostButton.defaultMessage })).toBeInTheDocument();
     });
@@ -176,6 +181,7 @@ describe('ReleaseNotes', () => {
       useReleaseNotes.mockReturnValue({
         ...mockUseReleaseNotes,
         notes: [mockReleaseNotes[0]],
+        hasAccess: true,
       });
       renderReleaseNotes();
       expect(screen.getByTestId('release-note-edit-button')).toBeInTheDocument();
@@ -186,6 +192,7 @@ describe('ReleaseNotes', () => {
       useReleaseNotes.mockReturnValue({
         ...mockUseReleaseNotes,
         notes: [mockReleaseNotes[0]],
+        hasAccess: true,
       });
       renderReleaseNotes();
       expect(screen.getByTestId('release-note-delete-button')).toBeInTheDocument();
@@ -251,6 +258,7 @@ describe('ReleaseNotes', () => {
       getAuthenticatedUser.mockReturnValue({ administrator: true });
       useReleaseNotes.mockReturnValue({
         ...mockUseReleaseNotes,
+        hasAccess: true,
         handleOpenUpdateForm,
       });
       renderReleaseNotes();
@@ -344,6 +352,7 @@ describe('ReleaseNotes', () => {
       useReleaseNotes.mockReturnValue({
         ...mockUseReleaseNotes,
         notes: [mockReleaseNotes[0]],
+        hasAccess: true,
         isFormOpen: true,
       });
       renderReleaseNotes();
@@ -360,6 +369,7 @@ describe('ReleaseNotes', () => {
       useReleaseNotes.mockReturnValue({
         ...mockUseReleaseNotes,
         notes: [mockReleaseNotes[0]],
+        hasAccess: true,
         handleOpenUpdateForm,
       });
       renderReleaseNotes();
@@ -375,6 +385,7 @@ describe('ReleaseNotes', () => {
       useReleaseNotes.mockReturnValue({
         ...mockUseReleaseNotes,
         notes: [mockReleaseNotes[0]],
+        hasAccess: true,
         handleOpenDeleteForm,
       });
       renderReleaseNotes();

--- a/src/release-notes/data/selectors.js
+++ b/src/release-notes/data/selectors.js
@@ -1,4 +1,5 @@
 export const getReleaseNotes = (state) => state.releaseNotes.releaseNotes;
+export const getHasAccess = (state) => state.releaseNotes.hasAccess;
 export const getSavingStatuses = (state) => state.releaseNotes.savingStatuses;
 export const getLoadingStatuses = (state) => state.releaseNotes.loadingStatuses;
 export const getErrors = (state) => state.releaseNotes.errors;

--- a/src/release-notes/data/slice.js
+++ b/src/release-notes/data/slice.js
@@ -4,6 +4,7 @@ import { sortBy } from 'lodash';
 
 const initialState = {
   releaseNotes: [],
+  hasAccess: false,
   savingStatuses: {
     createReleaseNoteQuery: '',
     editReleaseNoteQuery: '',
@@ -25,7 +26,8 @@ const slice = createSlice({
   initialState,
   reducers: {
     fetchReleaseNotesSuccess: (state, { payload }) => {
-      state.releaseNotes = payload;
+      state.releaseNotes = payload.notes || payload;
+      state.hasAccess = payload.hasAccess || false;
     },
     createReleaseNote: (state, { payload }) => {
       state.releaseNotes = [payload, ...state.releaseNotes];

--- a/src/release-notes/data/thunk.js
+++ b/src/release-notes/data/thunk.js
@@ -20,8 +20,10 @@ export function fetchReleaseNotesQuery() {
   return async (dispatch) => {
     try {
       dispatch(updateLoadingStatuses({ fetchReleaseNotesQuery: RequestStatus.IN_PROGRESS }));
-      const notes = await getReleaseNotes();
-      const normalized = (notes || []).map((n) => ({
+      const response = await getReleaseNotes();
+      const notesList = Array.isArray(response) ? response : (response.results || []);
+      const hasAccess = response.hasAccess || false;
+      const normalized = (notesList || []).map((n) => ({
         id: n.id,
         title: n.title,
         description: n.rawHtmlContent,
@@ -33,7 +35,7 @@ export function fetchReleaseNotesQuery() {
           const tb = b.published_at ? Date.parse(b.published_at) : -Infinity;
           return tb - ta;
         });
-      dispatch(fetchReleaseNotesSuccess(normalized));
+      dispatch(fetchReleaseNotesSuccess({ notes: normalized, hasAccess }));
       dispatch(updateLoadingStatuses({
         status: { fetchReleaseNotesQuery: RequestStatus.SUCCESSFUL },
         error: { loadingNotes: false },

--- a/src/release-notes/data/thunk.test.js
+++ b/src/release-notes/data/thunk.test.js
@@ -40,8 +40,9 @@ describe('release-notes thunks', () => {
 
     expect(actions[0].type).toBe(updateLoadingStatuses.type);
     const success = actions.find(a => a.type === fetchReleaseNotesSuccess.type);
-    expect(success.payload[0].id).toBe(2);
-    expect(success.payload[0]).toEqual(expect.objectContaining({ description: '<p>b</p>', published_at: expect.any(String), created_by: 'b@x' }));
+    expect(success.payload.notes[0].id).toBe(2);
+    expect(success.payload.notes[0]).toEqual(expect.objectContaining({ description: '<p>b</p>', published_at: expect.any(String), created_by: 'b@x' }));
+    expect(success.payload.hasAccess).toBe(false);
     const last = actions[actions.length - 1];
     expect(last.type).toBe(updateLoadingStatuses.type);
     expect(last.payload.status.fetchReleaseNotesQuery).toBe(RequestStatus.SUCCESSFUL);

--- a/src/release-notes/hooks.jsx
+++ b/src/release-notes/hooks.jsx
@@ -12,6 +12,7 @@ import {
 } from './data/thunk';
 import {
   getReleaseNotes as selectReleaseNotes,
+  getHasAccess,
   getLoadingStatuses,
   getSavingStatuses,
   getErrors,
@@ -29,6 +30,7 @@ const useReleaseNotes = () => {
   const [currentNote, setCurrentNote] = useState(initialNote);
 
   const notes = useSelector(selectReleaseNotes) || [];
+  const hasAccess = useSelector(getHasAccess);
   const loadingStatuses = useSelector(getLoadingStatuses);
   const savingStatuses = useSelector(getSavingStatuses);
   const errors = useSelector(getErrors);
@@ -102,6 +104,7 @@ const useReleaseNotes = () => {
   return {
     requestType,
     notes,
+    hasAccess,
     notesInitialValues,
     isMainFormOpen: isFormOpen && requestType !== REQUEST_TYPES.edit_update,
     isInnerFormOpen: (id) => (


### PR DESCRIPTION
### Description

- This PR introduces a Waffle feature flag to control CRUD permissions for release notes in the UI. The flag determines whether users can create, edit, and delete release notes, and updates both the frontend and Redux state accordingly.

`release_notes.enable_release_notes_actions`

### Jira

- https://2u-internal.atlassian.net/browse/TNL2-457
