### PR TITLE
fix: show XBlock editor after Games block creation

### DIFF
--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -188,7 +188,15 @@ const AddComponent = ({
         });
         break;
       case COMPONENT_TYPES.games:
-        handleCreateNewCourseXBlock({ type, category: type, parentLocator: blockId });
+        handleCreateNewCourseXBlock(
+          { type, category: type, parentLocator: blockId },
+          ({ courseKey, locator }) => {
+            setCourseId(courseKey);
+            setBlockType(type);
+            setNewBlockId(locator);
+            showXBlockEditorModal();
+          },
+        );
         break;
       default:
     }

--- a/src/editors/containers/GameEditor/index.jsx
+++ b/src/editors/containers/GameEditor/index.jsx
@@ -44,12 +44,17 @@ import DraggableList, { SortableItem } from '../../../generic/DraggableList';
 import messages from './messages';
 
 export const hooks = {
-  getContent: ({ type, settings, list }) => ({
-    gameType: type,
-    isShuffled: settings.shuffle,
-    hasTimer: settings.timer,
-    cards: list,
-  }),
+  getContent: ({ type, settings, list }) => {
+    // Filter out completely blank cards before saving
+    const filledCards = list.filter(card => card.term.trim() !== '' || card.definition.trim() !== '');
+
+    return {
+      gameType: type,
+      isShuffled: settings.shuffle,
+      hasTimer: settings.timer,
+      cards: filledCards,
+    };
+  },
 };
 
 export const GameEditor = ({

--- a/src/editors/containers/GameEditor/index.jsx
+++ b/src/editors/containers/GameEditor/index.jsx
@@ -45,8 +45,14 @@ import messages from './messages';
 
 export const hooks = {
   getContent: ({ type, settings, list }) => {
-    // Filter out completely blank cards before saving
-    const filledCards = list.filter(card => card.term.trim() !== '' || card.definition.trim() !== '');
+    // Filter out completely blank cards before saving (no text and no images)
+    const filledCards = list.filter((card) => {
+      const termText = (card.term || '').trim();
+      const definitionText = (card.definition || '').trim();
+      const hasText = termText !== '' || definitionText !== '';
+      const hasImages = !!card.term_image || !!card.definition_image;
+      return hasText || hasImages;
+    });
 
     return {
       gameType: type,
@@ -153,8 +159,21 @@ export const GameEditor = ({
     list.forEach((card, index) => {
       const termEmpty = !card.term.trim();
       const definitionEmpty = !card.definition.trim();
+      const hasTermImage = !!card.term_image;
+      const hasDefinitionImage = !!card.definition_image;
 
       if (termEmpty && definitionEmpty) {
+        // For flashcards, if there's an image but no text, show validation error
+        if (type === 'flashcards' && (hasTermImage || hasDefinitionImage)) {
+          if (hasTermImage) {
+            errors[`${index}_term`] = 'imageWithoutText';
+            hasErrors = true;
+          }
+          if (hasDefinitionImage) {
+            errors[`${index}_definition`] = 'imageWithoutText';
+            hasErrors = true;
+          }
+        }
         return;
       }
 
@@ -167,11 +186,23 @@ export const GameEditor = ({
         errors[`${index}_definition`] = true;
         hasErrors = true;
       }
+
+      // For flashcards, validate that images have accompanying text
+      if (type === 'flashcards') {
+        if (hasTermImage && termEmpty) {
+          errors[`${index}_term`] = 'imageWithoutText';
+          hasErrors = true;
+        }
+        if (hasDefinitionImage && definitionEmpty) {
+          errors[`${index}_definition`] = 'imageWithoutText';
+          hasErrors = true;
+        }
+      }
     });
 
     setValidationErrors(errors);
     return !hasErrors;
-  }, [list]);
+  }, [list, type]);
 
   const getDescriptionHeader = () => {
     switch (type) {
@@ -462,7 +493,9 @@ export const GameEditor = ({
                             <span>
                               {getCardErrors(card, index).termError && (
                                 <Form.Control.Feedback type="invalid" hasIcon={false}>
-                                  {intl.formatMessage(messages.termValidationError)}
+                                  {validationErrors[`${index}_term`] === 'imageWithoutText'
+                                    ? intl.formatMessage(messages.imageWithoutTextError)
+                                    : intl.formatMessage(messages.termValidationError)}
                                 </Form.Control.Feedback>
                               )}
                             </span>
@@ -493,7 +526,9 @@ export const GameEditor = ({
                             <span>
                               {getCardErrors(card, index).definitionError && (
                                 <Form.Control.Feedback type="invalid" hasIcon={false}>
-                                  {intl.formatMessage(messages.definitionValidationError)}
+                                  {validationErrors[`${index}_definition`] === 'imageWithoutText'
+                                    ? intl.formatMessage(messages.imageWithoutTextError)
+                                    : intl.formatMessage(messages.definitionValidationError)}
                                 </Form.Control.Feedback>
                               )}
                             </span>

--- a/src/editors/containers/GameEditor/messages.ts
+++ b/src/editors/containers/GameEditor/messages.ts
@@ -73,7 +73,7 @@ const messages = defineMessages({
   },
   imageWithoutTextError: {
     id: 'GameEditor.imageWithoutTextError',
-    defaultMessage: 'Enter text for this card. Flashcard images must have accompanying text.',
+    defaultMessage: 'Text is required for flashcard images.',
     description: 'Error message when a flashcard has an image but no text',
   },
   settingsTitle: {

--- a/src/editors/containers/GameEditor/messages.ts
+++ b/src/editors/containers/GameEditor/messages.ts
@@ -71,6 +71,11 @@ const messages = defineMessages({
     defaultMessage: 'Enter a definition',
     description: 'Error message when definition field is empty but term is filled',
   },
+  imageWithoutTextError: {
+    id: 'GameEditor.imageWithoutTextError',
+    defaultMessage: 'Enter text for this card. Flashcard images must have accompanying text.',
+    description: 'Error message when a flashcard has an image but no text',
+  },
   settingsTitle: {
     id: 'GameEditor.settingsTitle',
     defaultMessage: 'Settings',

--- a/src/editors/data/redux/thunkActions/game.js
+++ b/src/editors/data/redux/thunkActions/game.js
@@ -17,25 +17,12 @@ export const loadGamesSettings = () => (dispatch) => {
     onSuccess: (response) => {
       const { data } = response;
 
-      if (data.game_type) {
-        dispatch(actions.game.updateType(data.game_type));
-      }
-
-      if (data.is_shuffled !== undefined) {
-        if (data.is_shuffled) {
-          dispatch(actions.game.setShuffleStatus(true));
-        } else {
-          dispatch(actions.game.setShuffleStatus(false));
-        }
-      }
-
-      if (data.has_timer !== undefined) {
-        if (data.has_timer) {
-          dispatch(actions.game.setTimerStatus(true));
-        } else {
-          dispatch(actions.game.setTimerStatus(false));
-        }
-      }
+      const gameType = data.game_type || 'matching';
+      dispatch(actions.game.updateType(gameType));
+      const isShuffled = data.is_shuffled !== undefined ? data.is_shuffled : true;
+      dispatch(actions.game.setShuffleStatus(isShuffled));
+      const hasTimer = data.has_timer !== undefined ? data.has_timer : true;
+      dispatch(actions.game.setTimerStatus(hasTimer));
 
       if (data.cards && data.cards.length > 0) {
         const formattedCards = data.cards.map((card, index) => ({
@@ -47,6 +34,16 @@ export const loadGamesSettings = () => (dispatch) => {
           editorOpen: true,
         }));
         dispatch(actions.game.setList(formattedCards));
+      } else {
+        const emptyCard = {
+          id: `card-${Date.now()}-0`,
+          term: '',
+          term_image: '',
+          definition: '',
+          definition_image: '',
+          editorOpen: true,
+        };
+        dispatch(actions.game.setList([emptyCard]));
       }
     },
     onFailure: (error) => {

--- a/src/editors/data/redux/thunkActions/game.test.js
+++ b/src/editors/data/redux/thunkActions/game.test.js
@@ -244,7 +244,7 @@ describe('game thunkActions', () => {
         expect(gameActions.setList).toHaveBeenCalledWith(expectedFormattedCards);
       });
 
-      it('should not dispatch any actions when response data is empty', () => {
+      it('should dispatch actions with default values when response data is empty', () => {
         const emptyResponse = { data: {} };
         const mockOnSuccess = jest.fn();
         requests.getGamesSettings.mockImplementation(({ onSuccess }) => {
@@ -252,13 +252,22 @@ describe('game thunkActions', () => {
           return jest.fn();
         });
 
+        const expectedEmptyCard = [{
+          id: `card-${mockDate}-0`,
+          term: '',
+          term_image: '',
+          definition: '',
+          definition_image: '',
+          editorOpen: true,
+        }];
+
         loadGamesSettings()(dispatch);
         mockOnSuccess(emptyResponse);
 
-        expect(gameActions.updateType).not.toHaveBeenCalled();
-        expect(gameActions.setShuffleStatus).not.toHaveBeenCalled();
-        expect(gameActions.setTimerStatus).not.toHaveBeenCalled();
-        expect(gameActions.setList).not.toHaveBeenCalled();
+        expect(gameActions.updateType).toHaveBeenCalledWith('matching');
+        expect(gameActions.setShuffleStatus).toHaveBeenCalledWith(true);
+        expect(gameActions.setTimerStatus).toHaveBeenCalledWith(true);
+        expect(gameActions.setList).toHaveBeenCalledWith(expectedEmptyCard);
       });
     });
 


### PR DESCRIPTION
## Description
 
This PR fixes an issue where the XBlock editor was not displayed after creating a Games block.
With this change, the editor now opens automatically upon creation, allowing authors to immediately configure the block.
It also improves error handling by ensuring relevant error messages are properly displayed when issues occur.
 
## Changes
 

- Ensured the XBlock editor is shown immediately after Games block creation
- Improved error handling to surface meaningful error messages to authors
- Enhanced the overall authoring experience for Games blocks

 
## Impact
 

- Authors can configure Games blocks right after creation without extra steps
- Clear error messages help authors understand and resolve issues faster
- No impact on existing XBlocks or learner-facing views 

## Testing
 

- Created a new Games block and verified the editor opens automatically
- Triggered error scenarios to confirm error messages are displayed correctly
- Confirmed existing Games blocks continue to function as expected

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-458
- https://2u-internal.atlassian.net/browse/TNL2-470

#### Video (After)

https://github.com/user-attachments/assets/32399268-3da1-4734-8e36-24c917c9590d


