### PR TITLE
feat: show all components on unit expand in outline page

### DIFF
--- a/src/course-outline/card-header/CardHeader.scss
+++ b/src/course-outline/card-header/CardHeader.scss
@@ -6,20 +6,22 @@
     justify-content: flex-start;
     padding: 0;
     flex: 1 1 0;
+    min-width: 0;
     height: 1.5rem;
     margin-right: .25rem;
     background: transparent;
     color: var(--pgn-color-black);
 
-      .truncate-1-line {
-        -webkit-line-clamp: 1;  /* stylelint-disable-line value-no-vendor-prefix */
-        line-clamp: 1;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        display: -webkit-box;  /* stylelint-disable-line value-no-vendor-prefix */
-        min-width: 100px;
-        -webkit-box-orient: vertical;  /* stylelint-disable-line value-no-vendor-prefix */
-      }
+    .truncate-1-line {
+      -webkit-line-clamp: 1;  /* stylelint-disable-line value-no-vendor-prefix */
+      line-clamp: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;  /* stylelint-disable-line value-no-vendor-prefix */
+      min-width: 100%;
+      text-align: left;
+      -webkit-box-orient: vertical;  /* stylelint-disable-line value-no-vendor-prefix */
+    }
   }
 
   .item-card-button-icon {

--- a/src/course-outline/drag-helper/SortableItem.tsx
+++ b/src/course-outline/drag-helper/SortableItem.tsx
@@ -60,6 +60,7 @@ const SortableItem = ({
     marginBottom: '1.5rem',
     borderRadius: '0.35rem',
     boxShadow: '0 0 .125rem rgba(0, 0, 0, .15), 0 0 .25rem rgba(0, 0, 0, .15)',
+    flexWrap: 'nowrap',
     ...componentStyle,
   };
 
@@ -69,7 +70,7 @@ const SortableItem = ({
       style={style}
       className="mx-0"
     >
-      <Col className="extend-margin px-0">
+      <Col className="extend-margin px-0" style={{ minWidth: 0 }}>
         {children}
       </Col>
       {isDraggable && (

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -20,6 +20,7 @@
       .component-item {
         background-color: var(--pgn-color-white);
         transition: box-shadow 0.2s, transform 0.1s;
+        min-width: 0;
 
         &:hover {
           box-shadow: 0 2px 4px rgba(0 0 0 / 0.1);
@@ -36,6 +37,8 @@
         }
 
         .component-name {
+          flex: 1;
+          min-width: 0;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -43,6 +43,14 @@
           overflow: hidden;
           text-overflow: ellipsis;
         }
+
+        .component-info {
+          max-width: calc(100% - 45px);
+        }
+
+        .component-card-button-icon:hover {
+          background-color: var(--pgn-color-icon-button-bg-primary-hover);
+        }
       }
     }
   }

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -11,4 +11,30 @@
     line-height: var(--pgn-typography-headings-line-height);
     color: var(--pgn-color-headings-base);
   }
+
+  .unit-card__components {
+    background-color: var(--pgn-color-light-100);
+    border-top: 1px solid var(--pgn-color-light-400);
+
+    .components-list {
+      .component-item {
+        background-color: var(--pgn-color-white);
+        transition: box-shadow 0.2s, transform 0.1s;
+
+        &:hover {
+          box-shadow: 0 2px 4px rgba(0 0 0 / 0.1);
+          transform: translateY(-1px);
+        }
+
+        &:active {
+          transform: translateY(0);
+        }
+
+        &:focus {
+          outline: 2px solid var(--pgn-color-primary-500);
+          outline-offset: 2px;
+        }
+      }
+    }
+  }
 }

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -34,6 +34,12 @@
           outline: 2px solid var(--pgn-color-primary-500);
           outline-offset: 2px;
         }
+
+        .component-name {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
       }
     }
   }

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -1,6 +1,7 @@
 import {
   act, fireEvent, initializeMocks, render, screen, waitFor, within,
 } from '@src/testUtils';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 
 import { XBlock } from '@src/data/types';
 import UnitCard from './UnitCard';
@@ -109,6 +110,7 @@ const renderComponent = (props?: object) => render(
 describe('<UnitCard />', () => {
   beforeEach(() => {
     initializeMocks();
+    mockWaffleFlags({ enableUnitExpandedView: true });
     mockUseUnitHandler.mockReset();
     mockUseUnitHandler.mockReturnValue({
       data: undefined, isLoading: false, isError: false, error: null,

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -8,6 +8,7 @@ import cardMessages from '../card-header/messages';
 
 const mockUseAcceptLibraryBlockChanges = jest.fn();
 const mockUseIgnoreLibraryBlockChanges = jest.fn();
+const mockUseUnitHandler = jest.fn();
 
 jest.mock('@src/course-unit/data/apiHooks', () => ({
   useAcceptLibraryBlockChanges: () => ({
@@ -16,6 +17,10 @@ jest.mock('@src/course-unit/data/apiHooks', () => ({
   useIgnoreLibraryBlockChanges: () => ({
     mutateAsync: mockUseIgnoreLibraryBlockChanges,
   }),
+}));
+
+jest.mock('./data/hooks', () => ({
+  useUnitHandler: (...args: unknown[]) => mockUseUnitHandler(...args),
 }));
 
 const section = {
@@ -104,16 +109,16 @@ const renderComponent = (props?: object) => render(
 describe('<UnitCard />', () => {
   beforeEach(() => {
     initializeMocks();
+    mockUseUnitHandler.mockReset();
+    mockUseUnitHandler.mockReturnValue({
+      data: undefined, isLoading: false, isError: false, error: null,
+    });
   });
 
   it('render UnitCard component correctly', async () => {
     const { findByTestId } = renderComponent();
 
     expect(await findByTestId('unit-card-header')).toBeInTheDocument();
-    expect(await findByTestId('unit-card-header__title-link')).toHaveAttribute(
-      'href',
-      '/some/block-v1:UNIX+UX1+2025_T3+type@unit+block@0',
-    );
   });
 
   it('hides header based on isHeaderVisible flag', async () => {
@@ -236,5 +241,23 @@ describe('<UnitCard />', () => {
     fireEvent.click(ignoreButton);
 
     await waitFor(() => expect(mockUseIgnoreLibraryBlockChanges).toHaveBeenCalled());
+  });
+
+  it('shows an error alert when unit components fail to load', async () => {
+    const errorMessage = 'Failed to load unit components';
+    mockUseUnitHandler.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error(errorMessage),
+    });
+
+    renderComponent();
+
+    const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+    fireEvent.click(expandButton);
+
+    expect(await screen.findByText(/unable to load unit components/i)).toBeInTheDocument();
+    expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
   });
 });

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -12,6 +12,8 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
+import { useWaffleFlags } from '@src/data/apiHooks';
+
 import CourseOutlineUnitCardExtraActionsSlot from '@src/plugin-slots/CourseOutlineUnitCardExtraActionsSlot';
 import { setCurrentItem, setCurrentSection, setCurrentSubsection } from '@src/course-outline/data/slice';
 import { fetchCourseSectionQuery } from '@src/course-outline/data/thunk';
@@ -19,6 +21,7 @@ import { RequestStatus, RequestStatusType } from '@src/data/constants';
 import CardHeader from '@src/course-outline/card-header/CardHeader';
 import SortableItem from '@src/course-outline/drag-helper/SortableItem';
 import TitleButton from '@src/course-outline/card-header/TitleButton';
+import TitleLink from '@src/course-outline/card-header/TitleLink';
 import XBlockStatus from '@src/course-outline/xblock-status/XBlockStatus';
 import { getItemStatus, getItemStatusBorder, scrollToElement } from '@src/course-outline/utils';
 import { useClipboard } from '@src/generic/clipboard';
@@ -76,6 +79,7 @@ const UnitCard = ({
   const currentRef = useRef(null);
   const dispatch = useDispatch();
   const intl = useIntl();
+  const waffleFlags = useWaffleFlags();
   const [searchParams] = useSearchParams();
   const locatorId = searchParams.get('show');
   const isScrolledToElement = locatorId === unit.id;
@@ -102,13 +106,13 @@ const UnitCard = ({
     upstreamInfo,
   } = unit;
 
-  // Fetch unit components when expanded
+  // Fetch unit components when expanded (only if flag is enabled)
   const {
     data: unitData,
     isLoading: isLoadingComponents,
     isError: isComponentsError,
     error: componentsError,
-  } = useUnitHandler(id, isExpanded);
+  } = useUnitHandler(id, isExpanded && waffleFlags.enableUnitExpandedView);
 
   const blockSyncData = useMemo(() => {
     if (!upstreamInfo?.readyToSync) {
@@ -190,11 +194,18 @@ const UnitCard = ({
     }
   }, [dispatch, section, queryClient, courseId]);
 
-  const titleComponent = (
+  const titleComponent = waffleFlags.enableUnitExpandedView ? (
     <TitleButton
       title={displayName}
       isExpanded={isExpanded}
       onTitleClick={handleExpandContent}
+      namePrefix={namePrefix}
+      prefixIcon={<UpstreamInfoIcon upstreamInfo={upstreamInfo} size="sm" />}
+    />
+  ) : (
+    <TitleLink
+      title={displayName}
+      titleLink={getTitleLink(id)}
       namePrefix={namePrefix}
       prefixIcon={<UpstreamInfoIcon upstreamInfo={upstreamInfo} size="sm" />}
     />
@@ -295,7 +306,7 @@ const UnitCard = ({
           </div>
 
           {/* Components section - shown when expanded like section/subsection */}
-          {isExpanded && (
+          {waffleFlags.enableUnitExpandedView && isExpanded && (
             <div className="unit-card__components p-3" data-testid="unit-card__components">
               {(() => {
                 if (isComponentsError) {

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -3,12 +3,14 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { useDispatch } from 'react-redux';
-import { useToggle } from '@openedx/paragon';
+import { useToggle, Icon } from '@openedx/paragon';
 import { isEmpty } from 'lodash';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import CourseOutlineUnitCardExtraActionsSlot from '@src/plugin-slots/CourseOutlineUnitCardExtraActionsSlot';
 import { setCurrentItem, setCurrentSection, setCurrentSubsection } from '@src/course-outline/data/slice';
@@ -16,7 +18,7 @@ import { fetchCourseSectionQuery } from '@src/course-outline/data/thunk';
 import { RequestStatus, RequestStatusType } from '@src/data/constants';
 import CardHeader from '@src/course-outline/card-header/CardHeader';
 import SortableItem from '@src/course-outline/drag-helper/SortableItem';
-import TitleLink from '@src/course-outline/card-header/TitleLink';
+import TitleButton from '@src/course-outline/card-header/TitleButton';
 import XBlockStatus from '@src/course-outline/xblock-status/XBlockStatus';
 import { getItemStatus, getItemStatusBorder, scrollToElement } from '@src/course-outline/utils';
 import { useClipboard } from '@src/generic/clipboard';
@@ -24,6 +26,10 @@ import { UpstreamInfoIcon } from '@src/generic/upstream-info-icon';
 import { PreviewLibraryXBlockChanges } from '@src/course-unit/preview-changes';
 import { invalidateLinksQuery } from '@src/course-libraries/data/apiHooks';
 import type { XBlock } from '@src/data/types';
+import { getItemIcon, getComponentStyleColor } from '@src/generic/block-type-utils';
+import AlertError from '@src/generic/alert-error';
+import { useUnitHandler } from './data/hooks';
+import messages from './messages';
 
 interface UnitCardProps {
   unit: XBlock;
@@ -69,11 +75,13 @@ const UnitCard = ({
 }: UnitCardProps) => {
   const currentRef = useRef(null);
   const dispatch = useDispatch();
+  const intl = useIntl();
   const [searchParams] = useSearchParams();
   const locatorId = searchParams.get('show');
   const isScrolledToElement = locatorId === unit.id;
   const [isFormOpen, openForm, closeForm] = useToggle(false);
   const [isSyncModalOpen, openSyncModal, closeSyncModal] = useToggle(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const namePrefix = 'unit';
 
   const { copyToClipboard } = useClipboard();
@@ -93,6 +101,14 @@ const UnitCard = ({
     discussionEnabled,
     upstreamInfo,
   } = unit;
+
+  // Fetch unit components when expanded
+  const {
+    data: unitData,
+    isLoading: isLoadingComponents,
+    isError: isComponentsError,
+    error: componentsError,
+  } = useUnitHandler(id, isExpanded);
 
   const blockSyncData = useMemo(() => {
     if (!upstreamInfo?.readyToSync) {
@@ -158,6 +174,15 @@ const UnitCard = ({
     copyToClipboard(id);
   };
 
+  const handleExpandContent = () => {
+    setIsExpanded((prevState) => !prevState);
+  };
+
+  const handleComponentClick = (blockId?: string) => {
+    const baseUrl = getTitleLink(id);
+    window.location.href = blockId ? `${baseUrl}#${blockId}` : baseUrl;
+  };
+
   const handleOnPostChangeSync = useCallback(() => {
     dispatch(fetchCourseSectionQuery([section.id]));
     if (courseId) {
@@ -166,9 +191,10 @@ const UnitCard = ({
   }, [dispatch, section, queryClient, courseId]);
 
   const titleComponent = (
-    <TitleLink
+    <TitleButton
       title={displayName}
-      titleLink={getTitleLink(id)}
+      isExpanded={isExpanded}
+      onTitleClick={handleExpandContent}
       namePrefix={namePrefix}
       prefixIcon={<UpstreamInfoIcon upstreamInfo={upstreamInfo} size="sm" />}
     />
@@ -267,6 +293,72 @@ const UnitCard = ({
               blockData={unit}
             />
           </div>
+
+          {/* Components section - shown when expanded like section/subsection */}
+          {isExpanded && (
+            <div className="unit-card__components p-3" data-testid="unit-card__components">
+              {(() => {
+                if (isComponentsError) {
+                  return (
+                    <AlertError
+                      error={componentsError}
+                      title={intl.formatMessage(messages.componentsLoadError)}
+                      showErrorBody={false}
+                    />
+                  );
+                }
+                if (isLoadingComponents) {
+                  return <div className="text-center p-3">{intl.formatMessage(messages.loadingComponents)}</div>;
+                }
+                if (unitData?.components && unitData.components.length > 0) {
+                  return (
+                    <div className="components-list">
+                      {unitData.components.map((component) => {
+                        const ComponentIcon = getItemIcon(component.blockType);
+                        const colorClass = getComponentStyleColor(component.blockType);
+
+                        return (
+                          <div
+                            key={component.blockId}
+                            className={`component-item d-flex align-items-center p-2 mb-2 border rounded ${colorClass}`}
+                            role="button"
+                            tabIndex={0}
+                            onClick={() => handleComponentClick(component.blockId)}
+                            onKeyPress={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                handleComponentClick(component.blockId);
+                              }
+                            }}
+                          >
+                            <Icon src={ComponentIcon} className="mr-2 text-dark" />
+                            <span className="component-name">{component.displayName}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                }
+                return (
+                  <div
+                    className="text-center text-muted p-3"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => handleComponentClick()}
+                    onKeyPress={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleComponentClick();
+                      }
+                    }}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {intl.formatMessage(messages.noComponents)}
+                  </div>
+                );
+              })()}
+            </div>
+          )}
         </div>
       </SortableItem>
       {blockSyncData && (

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -6,7 +6,8 @@ import {
   useState,
 } from 'react';
 import { useDispatch } from 'react-redux';
-import { useToggle, Icon } from '@openedx/paragon';
+import { useToggle, Icon, IconButtonWithTooltip } from '@openedx/paragon';
+import { EditOutline as EditIcon } from '@openedx/paragon/icons';
 import { isEmpty } from 'lodash';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
@@ -187,6 +188,12 @@ const UnitCard = ({
     window.location.href = blockId ? `${baseUrl}#${blockId}` : baseUrl;
   };
 
+  const handleComponentEdit = (e: React.MouseEvent, blockType: string, blockId: string) => {
+    e.stopPropagation();
+    const editorUrl = `/course/${courseId}/editor/${blockType}/${blockId}`;
+    window.location.href = editorUrl;
+  };
+
   const handleOnPostChangeSync = useCallback(() => {
     dispatch(fetchCourseSectionQuery([section.id]));
     if (courseId) {
@@ -331,7 +338,7 @@ const UnitCard = ({
                         return (
                           <div
                             key={component.blockId}
-                            className={`component-item d-flex align-items-center p-2 mb-2 border rounded ${colorClass}`}
+                            className={`component-item d-flex align-items-center justify-content-between p-2 mb-2 border rounded ${colorClass}`}
                             role="button"
                             tabIndex={0}
                             onClick={() => handleComponentClick(component.blockId)}
@@ -342,8 +349,18 @@ const UnitCard = ({
                               }
                             }}
                           >
-                            <Icon src={ComponentIcon} className="mr-2 text-dark" />
-                            <span className="component-name">{component.displayName}</span>
+                            <div className="d-flex align-items-center component-info">
+                              <Icon src={ComponentIcon} className="mr-2 text-dark" />
+                              <span className="component-name">{component.displayName}</span>
+                            </div>
+                            <IconButtonWithTooltip
+                              className="component-card-button-icon btn-icon btn-icon-primary btn-icon-md"
+                              data-testid="component-edit-button"
+                              alt={intl.formatMessage(messages.editComponent)}
+                              tooltipContent={<div>{intl.formatMessage(messages.editComponent)}</div>}
+                              iconAs={EditIcon}
+                              onClick={(e) => handleComponentEdit(e, component.blockType, component.blockId)}
+                            />
                           </div>
                         );
                       })}
@@ -362,7 +379,6 @@ const UnitCard = ({
                         handleComponentClick();
                       }
                     }}
-                    style={{ cursor: 'pointer' }}
                   >
                     {intl.formatMessage(messages.noComponents)}
                   </div>

--- a/src/course-outline/unit-card/data/api.ts
+++ b/src/course-outline/unit-card/data/api.ts
@@ -1,0 +1,28 @@
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+const getStudioBaseUrl = () => getConfig().STUDIO_BASE_URL;
+
+export interface UnitComponent {
+  blockId: string;
+  blockType: string;
+  displayName: string;
+}
+
+export interface UnitHandlerData {
+  unitId: string;
+  displayName: string;
+  components: UnitComponent[];
+}
+
+export const getUnitHandlerApiUrl = (unitId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/unit_handler/${unitId}`;
+
+/**
+ * Get unit handler data.
+ * @param {string} unitId
+ * @returns {Promise<UnitHandlerData>}
+ */
+export async function getUnitHandler(unitId: string): Promise<UnitHandlerData> {
+  const { data } = await getAuthenticatedHttpClient().get(getUnitHandlerApiUrl(unitId));
+  return camelCaseObject(data) as UnitHandlerData;
+}

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUnitHandler } from './api';
+
+export const useUnitHandler = (unitId: string, enabled: boolean = true) => useQuery({
+  queryKey: ['unitHandler', unitId],
+  queryFn: () => getUnitHandler(unitId),
+  enabled: enabled && !!unitId,
+});

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUnitHandler } from './api';
 
-export const useUnitHandler = (unitId: string, enabled: boolean = true) => useQuery({
+export const useUnitHandler = (unitId: string, enabled: boolean = false) => useQuery({
   queryKey: ['unitHandler', unitId],
   queryFn: () => getUnitHandler(unitId),
   enabled: enabled && !!unitId,

--- a/src/course-outline/unit-card/messages.js
+++ b/src/course-outline/unit-card/messages.js
@@ -1,0 +1,21 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  loadingComponents: {
+    id: 'course-authoring.course-outline.unit.loading-components',
+    defaultMessage: 'Loading components...',
+    description: 'Message shown while unit components are being loaded',
+  },
+  noComponents: {
+    id: 'course-authoring.course-outline.unit.no-components',
+    defaultMessage: 'No components - Click to open unit editor',
+    description: 'Message shown when a unit has no components',
+  },
+  componentsLoadError: {
+    id: 'course-authoring.course-outline.unit.components-load-error',
+    defaultMessage: 'Unable to load unit components. Please try again.',
+    description: 'Message shown when the unit components request fails',
+  },
+});
+
+export default messages;

--- a/src/course-outline/unit-card/messages.js
+++ b/src/course-outline/unit-card/messages.js
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Unable to load unit components. Please try again.',
     description: 'Message shown when the unit components request fails',
   },
+  editComponent: {
+    id: 'course-authoring.course-outline.unit.edit-component',
+    defaultMessage: 'Edit component',
+    description: 'Label for the button to edit a component',
+  },
 });
 
 export default messages;

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -33,6 +33,7 @@ export async function getCourseDetail(courseId: string, username: string) {
 export const waffleFlagDefaults = {
   enableCourseOptimizer: false,
   enableCourseOptimizerCheckPrevRunLinks: false,
+  enableUnitExpandedView: false,
   useNewHomePage: true,
   useNewCustomPages: true,
   useNewScheduleDetailsPage: true,

--- a/src/generic/alert-error/AlertError.test.tsx
+++ b/src/generic/alert-error/AlertError.test.tsx
@@ -4,9 +4,9 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import AlertError from '.';
 
-const RootWrapper = ({ error }: { error: unknown }) => (
+const RootWrapper = ({ error, showErrorBody = true }: { error: unknown, showErrorBody?: boolean }) => (
   <IntlProvider locale="en">
-    <AlertError error={error} />
+    <AlertError error={error} showErrorBody={showErrorBody} />
   </IntlProvider>
 );
 
@@ -35,5 +35,11 @@ describe('<AlertMessage />', () => {
     const { getByText } = render(<RootWrapper error={error} />);
     expect(getByText(/this is an error message/i)).toBeInTheDocument();
     expect(getByText(/\{ "message": "this is a response body" \}/i)).toBeInTheDocument();
+  });
+
+  test('hides error body when requested', () => {
+    const error = new Error('Hidden body');
+    const { queryByText } = render(<RootWrapper error={error} showErrorBody={false} />);
+    expect(queryByText(/Hidden body/i)).not.toBeInTheDocument();
   });
 });

--- a/src/generic/alert-error/index.tsx
+++ b/src/generic/alert-error/index.tsx
@@ -8,10 +8,13 @@ export interface AlertErrorProps {
   error: unknown;
   title?: string;
   onDismiss?: () => void;
+  showErrorBody?: boolean;
 }
 
 /* eslint-disable react/prop-types */
-const AlertError: React.FC<AlertErrorProps> = ({ error, title, onDismiss }) => {
+const AlertError: React.FC<AlertErrorProps> = ({
+  error, title, onDismiss, showErrorBody = true,
+}) => {
   const intl = useIntl();
   let errorDetails: string | undefined;
   if (error instanceof Object && (error as any).response?.data) {
@@ -31,12 +34,18 @@ const AlertError: React.FC<AlertErrorProps> = ({ error, title, onDismiss }) => {
       onClose={onDismiss}
     >
       {title && <Alert.Heading>{title}</Alert.Heading>}
-      {error instanceof Object && 'message' in error ? String(error.message) : String(error)}
-      <br />
-      {errorDetails && (
-        <pre>
-          {errorDetails}
-        </pre>
+      {showErrorBody && (
+        <>
+          {error instanceof Object && 'message' in error ? String(error.message) : String(error)}
+          {errorDetails && (
+            <>
+              <br />
+              <pre>
+                {errorDetails}
+              </pre>
+            </>
+          )}
+        </>
       )}
     </Alert>
   );

--- a/src/generic/block-type-utils/H5pIcon.tsx
+++ b/src/generic/block-type-utils/H5pIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const H5pIcon: React.FC = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="H5P"
+  >
+    <text
+      x="12"
+      y="17"
+      textAnchor="middle"
+      fontFamily="Arial, Helvetica, sans-serif"
+      fontSize="10"
+      fontWeight="700"
+      fill="var(--pgn-color-headings-base)"
+    >
+      H5P
+    </text>
+  </svg>
+);
+
+export default H5pIcon;

--- a/src/generic/block-type-utils/LtiIcon.tsx
+++ b/src/generic/block-type-utils/LtiIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const LtiIcon: React.FC = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="LTI"
+  >
+    <rect width="24" height="24" rx="2" fill="none" />
+    <text
+      x="12"
+      y="17"
+      textAnchor="middle"
+      fontFamily="Arial, Helvetica, sans-serif"
+      fontSize="12"
+      fontWeight="700"
+      fill="var(--pgn-color-headings-base)"
+    >
+      LTI
+    </text>
+  </svg>
+);
+
+export default LtiIcon;

--- a/src/generic/block-type-utils/ScormIcon.tsx
+++ b/src/generic/block-type-utils/ScormIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const ScormIcon: React.FC = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="SCORM"
+  >
+    <path
+      d="M17 6.5C17 4.6 14.8 3 12 3C9.2 3 7 4.6 7 6.8C7 9 9.5 9.8 12 10.4C14.5 11 17 11.7 17 14.2C17 16.4 14.8 18 12 18C9.2 18 7 16.4 7 14.5"
+      fill="none"
+      stroke="var(--pgn-color-headings-base)"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export default ScormIcon;

--- a/src/generic/block-type-utils/constants.ts
+++ b/src/generic/block-type-utils/constants.ts
@@ -21,6 +21,9 @@ import {
   Award as GamesIcon,
 } from '@openedx/paragon/icons';
 import NewsstandIcon from '../NewsstandIcon';
+import LtiIcon from './LtiIcon';
+import ScormIcon from './ScormIcon';
+import H5pIcon from './H5pIcon';
 
 export const UNIT_ICON_TYPES = ['video', 'other', 'vertical', 'problem', 'lock'];
 
@@ -36,6 +39,9 @@ export const COMPONENT_TYPES = {
   video: 'video',
   dragAndDrop: 'drag-and-drop-v2',
   games: 'games',
+  lti: 'lti_consumer',
+  scorm: 'scorm',
+  h5p: 'h5pxblock',
 };
 
 export const UNIT_TYPE_ICONS_MAP: Record<string, React.ComponentType> = {
@@ -61,6 +67,9 @@ export const COMPONENT_TYPE_ICON_MAP: Record<string, React.ComponentType> = {
   [COMPONENT_TYPES.video]: VideoCameraIcon,
   [COMPONENT_TYPES.dragAndDrop]: BackHandIcon,
   [COMPONENT_TYPES.games]: GamesIcon,
+  [COMPONENT_TYPES.lti]: LtiIcon,
+  [COMPONENT_TYPES.scorm]: ScormIcon,
+  [COMPONENT_TYPES.h5p]: H5pIcon,
 };
 
 export const STRUCTURAL_TYPE_ICONS: Record<string, React.ComponentType> = {
@@ -85,6 +94,9 @@ export const COMPONENT_TYPE_STYLE_COLOR_MAP = {
   [COMPONENT_TYPES.problem]: 'component-style-default',
   [COMPONENT_TYPES.video]: 'component-style-video',
   [COMPONENT_TYPES.dragAndDrop]: 'component-style-default',
+  [COMPONENT_TYPES.lti]: 'component-style-default',
+  [COMPONENT_TYPES.scorm]: 'component-style-default',
+  [COMPONENT_TYPES.h5p]: 'component-style-default',
   vertical: 'component-style-vertical',
   unit: 'component-style-vertical',
   sequential: 'component-style-sequential',

--- a/src/studio-home/scss/StudioHome.scss
+++ b/src/studio-home/scss/StudioHome.scss
@@ -61,6 +61,7 @@
 
   .pgn__card-header {
     padding: .9375rem 1.25rem;
+    width: 100%;
 
     .pgn__card-header-content {
       margin: 0;


### PR DESCRIPTION
### Description

- This pull request adds functionality to expand units in the course outline page to display their individual components (similar to how sections and subsections expand). When a unit is expanded, it fetches and displays a list of components including new support for LTI, SCORM, and H5P component types.

- Access to this feature is controlled by a course-level waffle flag (enableUnitExpandedView). When the flag is disabled, unit expansion is not available, and unit titles fall back to navigational links. When enabled, units behave as expandable cards with inline component details.

**Key changes:**

- Added three new icon components (LtiIcon, ScormIcon, H5pIcon) with corresponding mappings in the component type constants
- Implemented expand/collapse functionality for unit cards with API integration to fetch component data, gated by the enableUnitExpandedView waffle flag
- Integrated a new data layer (API hooks) to retrieve unit component information from the backend
- Updated tests to mock the waffle flag state and verify conditional rendering

### Jira

- https://2u-internal.atlassian.net/browse/TNL2-473

**Before**

https://github.com/user-attachments/assets/f9095df1-251a-4710-80ad-d128b7bce083

**After**


https://github.com/user-attachments/assets/61126f23-3921-413e-b2f5-a0c03039b349





