### PR TITLE
fix: Scope Release Notes modal header/title styles to prevent global Paragon overrides

### DIFF
--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -258,6 +258,7 @@ const ReleaseNotes = () => {
         isOpen={isFormOpen}
         onClose={confirmCloseIfDirty}
         size="xl"
+        className="release-notes-modal"
       >
         <ModalDialog.Header>
           <ModalDialog.Title>
@@ -292,7 +293,12 @@ const ReleaseNotes = () => {
         errorDeleting={errors.deletingNote}
       />
       {isUnsavedModalOpen && (
-        <ModalDialog isOpen size="md" onClose={() => setIsUnsavedModalOpen(false)}>
+        <ModalDialog
+          isOpen
+          size="md"
+          onClose={() => setIsUnsavedModalOpen(false)}
+          className="release-notes-modal"
+        >
           <ModalDialog.Header>
             <ModalDialog.Title>
               {intl.formatMessage(unsavedMessages.unsavedModalTitle)}

--- a/src/release-notes/ReleaseNotes.scss
+++ b/src/release-notes/ReleaseNotes.scss
@@ -208,9 +208,19 @@
     color: inherit;
 }
 
-.pgn__modal-header .pgn__modal-title {
-	color: #00262B;
+// NOTE:
+// Modals are portalled to <body> (see Paragon ModalLayer/Portal), so selectors
+// like `.release-notes-page ...` will NOT scope modal styles to this page.
+//
+// A previous global override here was impacting unrelated Paragon modals
+// (notably dark-variant FullscreenModal titles), causing insufficient contrast.
+//
+// Scope any Release Notes modal title adjustments to Release Notes modals only.
+.release-notes-modal {
+  .pgn__modal-header .pgn__modal-title {
+    color: #00262B;
     font-size: 24px;
+  }
 }
 
 .pgn__form-text-default {
@@ -226,7 +236,7 @@
     font-size: 40px;
 }
 
-.pgn__modal.pgn__modal-xl.pgn__modal-default {
+.release-notes-modal.pgn__modal.pgn__modal-xl.pgn__modal-default {
     max-height: unset;
 }
 

--- a/src/release-notes/delete-modal/DeleteModal.jsx
+++ b/src/release-notes/delete-modal/DeleteModal.jsx
@@ -22,6 +22,7 @@ const DeleteModal = ({
       title={intl.formatMessage(messages.deleteModalTitle)}
       isOpen={isOpen}
       onClose={close}
+      className="release-notes-modal"
       footerNode={(
         <ActionRow>
           <Button variant="tertiary" onClick={close}>


### PR DESCRIPTION
### Summary
Scopes Release Notes–specific modal header and title styles to a feature-level wrapper to prevent unintended global overrides of Paragon modal styles.

---

### Problem
Custom styles for `.pgn__modal-header` and `.pgn__modal-title` (including `#00262B` title color) were applied without a feature-specific root.

Since Paragon modals are rendered via a portal to `<body>`, these styles effectively became global and could impact other modals—especially dark/fullscreen modals such as Discussions settings—leading to contrast and accessibility issues.

---

### Solution
- Introduced a Release Notes–specific wrapper class: `.release-notes-modal`
- Scoped modal header/title styles under this wrapper in `ReleaseNotes.scss`
- Applied the wrapper class at the component level to all Release Notes modals, including:
  - Create/Edit Release Note modal
  - Unsaved changes confirmation modal
  - Delete confirmation modal

---

### Why this approach
- Page-level wrappers cannot scope Paragon modals due to portal rendering
- Applying a wrapper class directly on the modal root is the safest and most maintainable solution
- Preserves Paragon default behavior and accessibility across the rest of Studio

