### PR TITLE
fix: improve image upload error handling with detailed alert

### DIFF
--- a/src/editors/containers/EditorContainer/hooks.ts
+++ b/src/editors/containers/EditorContainer/hooks.ts
@@ -94,9 +94,16 @@ export const saveFailed = () => useSelector((rootState) => (
 ));
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
-export const uploadFailed = () => useSelector((rootState) => (
-  selectors.requests.isFailed(rootState, { requestKey: RequestKeys.uploadAsset })
-));
+export const uploadFailed = () => ({
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  uploadFailed: useSelector((rootState) => (
+    selectors.requests.isFailed(rootState, { requestKey: RequestKeys.uploadAsset })
+  )),
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  uploadFailedError: useSelector((rootState) => (
+    selectors.requests.error(rootState, { requestKey: RequestKeys.uploadAsset })
+  )),
+});
 
 export const createFailed = () => ({
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -13,6 +13,8 @@ import {
 import { Close } from '@openedx/paragon/icons';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 
+import ErrorAlert from '../../sharedComponents/ErrorAlerts/ErrorAlert';
+
 import { EditorComponent } from '../../EditorComponent';
 import TitleHeader from './components/TitleHeader';
 import * as hooks from './hooks';
@@ -65,16 +67,23 @@ const EditorContainer: React.FC<Props> = ({
   const dispatch = useDispatch();
   // Required to mark data as not dirty on save
   const [saved, setSaved] = React.useState(false);
+  const errorAlertRef = React.useRef<HTMLDivElement>(null);
   const isInitialized = hooks.isInitialized();
   const { isCancelConfirmOpen, openCancelConfirmModal, closeCancelConfirmModal } = hooks.cancelConfirmModalToggle();
   const handleCancel = hooks.handleCancel({ onClose, returnFunction });
   const { createFailed, createFailedError } = hooks.createFailed();
   const disableSave = !isInitialized;
   const saveFailed = hooks.saveFailed();
-  const uploadFailed = hooks.uploadFailed();
+  const { uploadFailed, uploadFailedError } = hooks.uploadFailed();
   const clearSaveFailed = hooks.clearSaveError({ dispatch });
   const clearCreateFailed = hooks.clearCreateError({ dispatch });
   const clearUploadFailed = hooks.clearUploadError({ dispatch });
+
+  React.useEffect(() => {
+    if (uploadFailed && errorAlertRef.current) {
+      errorAlertRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [uploadFailed]);
 
   const handleSave = hooks.handleSaveClicked({
     dispatch,
@@ -120,11 +129,6 @@ const EditorContainer: React.FC<Props> = ({
           {intl.formatMessage(messages.contentSaveFailed)}
         </Toast>
       )}
-      {uploadFailed && (
-        <Toast show onClose={clearUploadFailed}>
-          {intl.formatMessage(messages.contentSaveFailed)}
-        </Toast>
-      )}
       <CancelConfirmModal
         isOpen={isCancelConfirmOpen}
         closeCancelConfirmModal={closeCancelConfirmModal}
@@ -149,9 +153,22 @@ const EditorContainer: React.FC<Props> = ({
           />
         </div>
       </ModalDialog.Header>
-      <EditorModalBody>
+      <ModalDialog.Body className="pb-0">
+        <div ref={errorAlertRef}>
+          <ErrorAlert
+            isError={uploadFailed}
+            dismissError={clearUploadFailed}
+          >
+            {parseErrorMsg(
+              intl,
+              uploadFailedError,
+              messages.errorUploadMessageWithDetail,
+              messages.errorUploadMessage,
+            )}
+          </ErrorAlert>
+        </div>
         {isInitialized && children}
-      </EditorModalBody>
+      </ModalDialog.Body>
       <FooterWrapper>
         <ModalDialog.Footer className="shadow-sm">
           <ActionRow>

--- a/src/editors/containers/EditorContainer/messages.ts
+++ b/src/editors/containers/EditorContainer/messages.ts
@@ -57,6 +57,19 @@ const messages = defineMessages({
     defaultMessage: 'Save',
     description: 'Label for Save button',
   },
+  errorUploadMessage: {
+    id: 'course-authoring.library-authoring.upload-asset.error.text',
+    defaultMessage: 'There was an error uploading the file.',
+    description: 'Error: Content save failed. Please check recent changes and try again later.',
+  },
+  errorUploadMessageWithDetail: {
+    id: 'course-authoring.library-authoring.upload-asset.error.text-detail',
+    defaultMessage: 'There was an error uploading the file: {detail}',
+    description: (
+      'Error: Content save failed. Please check recent changes and try again later.'
+      + ' The {detail} text provides more information about the error.'
+    ),
+  },
 });
 
 export default messages;

--- a/src/editors/containers/GameEditor/index.jsx
+++ b/src/editors/containers/GameEditor/index.jsx
@@ -290,7 +290,10 @@ export const GameEditor = ({
   const handleImageRemove = useCallback((index, imageType, imageUrl) => {
     const id = `${imageType}_image_upload|${index}`;
     document.getElementById(id).value = '';
-    const filePath = imageUrl.replace(/^\/media\//, '');
+    let filePath = imageUrl;
+    if (filePath.includes('/media/')) {
+      filePath = filePath.substring(filePath.indexOf('/media/') + '/media/'.length);
+    }
     deleteGameImage({ index, imageType, filePath });
   }, [deleteGameImage]);
 
@@ -302,14 +305,16 @@ export const GameEditor = ({
     const temp = cardsData.slice();
     [temp[index], temp[index - 1]] = [temp[index - 1], temp[index]];
     setCardsData(temp);
-  }, [cardsData]);
+    setList(temp);
+  }, [cardsData, setList]);
 
   const moveCardDown = useCallback((index) => {
     if (index === cardsData.length - 1) { return; }
     const temp = cardsData.slice();
     [temp[index + 1], temp[index]] = [temp[index], temp[index + 1]];
     setCardsData(temp);
-  }, [cardsData]);
+    setList(temp);
+  }, [cardsData, setList]);
 
   const loading = (
     <div className="text-center p-6">

--- a/src/editors/data/redux/game/reducers.js
+++ b/src/editors/data/redux/game/reducers.js
@@ -43,11 +43,6 @@ const game = createSlice({
       ...state,
       type: payload,
       isDirty: true,
-      settings: {
-        ...state.settings,
-        shuffle: true,
-        timer: true,
-      },
     }),
     // Unified card field update
     updateCardField: (state, { payload }) => {

--- a/src/editors/data/redux/game/reducers.test.js
+++ b/src/editors/data/redux/game/reducers.test.js
@@ -93,30 +93,6 @@ describe('game reducer', () => {
     });
   });
 
-  describe('updateType action', () => {
-    it('should update type and reset settings to defaults', () => {
-      const testState = {
-        ...initialState,
-        type: 'matching',
-        settings: { shuffle: false, timer: false, customSetting: 'test' },
-        isDirty: false,
-      };
-      const action = actions.updateType('flashcards');
-      const result = reducer(testState, action);
-
-      expect(result).toEqual({
-        ...testState,
-        type: 'flashcards',
-        settings: {
-          ...testState.settings,
-          shuffle: true,
-          timer: true,
-        },
-        isDirty: true,
-      });
-    });
-  });
-
   describe('updateCardField action', () => {
     const testState = {
       ...initialState,


### PR DESCRIPTION
**Description**

- Improves upload failure handling by displaying a persistent, detailed error alert that scrolls into view. Also keeps list state in sync when reordering cards in the game editor.

**Jira**

- <a href="https://2u-internal.atlassian.net/browse/TNL2-483" rel="noreferrer noopener" title="https://2u-internal.atlassian.net/browse/tnl2-483" target="_blank">https://2u-internal.atlassian.net/browse/TNL2-483</a>

**Screenshot** 
![image (4)](https://github.com/user-attachments/assets/89b2f7dc-014c-4bfe-a258-a992dc33d563)


 