### PR TITLE
Replace "Open edX" with "edX" in Discussions configuration UI

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -147,7 +147,7 @@ describe('DiscussionsSettings', () => {
       // content has been loaded - prior to proceeding with our expectations.
       await waitForElementToBeRemoved(screen.queryByRole('status'));
 
-      await user.click(queryByLabelText(container, 'Select Open edX (legacy)'));
+      await user.click(queryByLabelText(container, 'Select edX (legacy)'));
       await user.click(queryByText(container, messages.nextButton.defaultMessage));
 
       expect(queryByTestId(container, 'appList')).not.toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -107,7 +107,7 @@ describe('OpenedXConfigForm', () => {
     expect(container.querySelector('h3')).toHaveTextContent('edX');
   });
 
-  test('new Open edX provider config', async () => {
+  test('new edX provider config', async () => {
     await mockStore({ ...legacyApiResponse, enable_in_context: true });
     createComponent(jest.fn(), createRef(), false);
     expect(queryByText(container, messages.visibilityInContext.defaultMessage)).toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -104,7 +104,7 @@ describe('OpenedXConfigForm', () => {
   test('title rendering', async () => {
     await mockStore(legacyApiResponse);
     createComponent();
-    expect(container.querySelector('h3')).toHaveTextContent('edX');
+    expect(container.querySelector('h3')).toHaveTextContent('edX (legacy)');
   });
 
   test('new edX provider config', async () => {

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -107,12 +107,12 @@ const messages = defineMessages({
   },
   'appName-legacy': {
     id: 'authoring.discussions.appConfigForm.appName-legacy',
-    defaultMessage: 'Open edX (legacy)',
+    defaultMessage: 'edX (legacy)',
     description: 'The name of the Legacy Open edX Discussions app.',
   },
   'appName-openedx': {
     id: 'authoring.discussions.appConfigForm.appName-openedx',
-    defaultMessage: 'Open edX',
+    defaultMessage: 'edX',
     description: 'The name of the new Open edX Discussions app.',
   },
   divisionByGroup: {

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -113,7 +113,7 @@ const messages = defineMessages({
   'appName-openedx': {
     id: 'authoring.discussions.appConfigForm.appName-openedx',
     defaultMessage: 'edX',
-    description: 'The name of the new Open edX Discussions app.',
+    description: 'The name of the new edX Discussions app.',
   },
   divisionByGroup: {
     id: 'authoring.discussions.builtIn.divisionByGroup',

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -108,7 +108,7 @@ const messages = defineMessages({
   'appName-legacy': {
     id: 'authoring.discussions.appConfigForm.appName-legacy',
     defaultMessage: 'edX (legacy)',
-    description: 'The name of the Legacy Open edX Discussions app.',
+    description: 'The name of the Legacy edX Discussions app.',
   },
   'appName-openedx': {
     id: 'authoring.discussions.appConfigForm.appName-openedx',


### PR DESCRIPTION
This PR updates **user-facing UI copy** in the Authoring “Pages & Resources → Discussions” configuration flow to replace:
- **Open edX → edX**
- **Open edX (legacy) → edX (legacy)**

This is a **copy-only** change; no behavior or identifiers are modified.

#### Screens / Flow Covered
1) **“Select a discussion tool for this course” (provider selection step)**
- Updates provider tile labels and the supported-features comparison table column header via the `appName-*` messages.

2) **“Settings” (next step after selecting a provider)**
- Any headings/descriptive text that reference the provider name via `appName-*` now display the updated labels.

#### Changes Made (Files)
- `frontend-app-authoring-release-ulmo/.../src/pages-and-resources/discussions/app-config-form/messages.js`
  - Updated `appName-openedx` and `appName-legacy` defaultMessages.
- `frontend-app-authoring-release-ulmo/.../src/pages-and-resources/discussions/DiscussionsSettings.test.jsx`
  - Updated test expectation label text for selecting the legacy provider.
- `frontend-app-authoring-release-ulmo/.../src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx`
  - Updated test name string (no behavior change).
