### PR TITLE
fix(editor): prevent focus outline on timer and shuffle toggle buttons

### DIFF
--- a/src/editors/containers/GameEditor/index.jsx
+++ b/src/editors/containers/GameEditor/index.jsx
@@ -367,14 +367,14 @@ export const GameEditor = ({
           <Button
             onClick={() => setTimerStatus(false)}
             variant={!settings.timer ? 'primary' : 'outline-primary'}
-            className="toggle-button rounded-0"
+            className="toggle-button rounded-0 timer-toggle-button"
           >
             {intl.formatMessage(messages.offLabel)}
           </Button>
           <Button
             onClick={() => setTimerStatus(true)}
             variant={settings.timer ? 'primary' : 'outline-primary'}
-            className="toggle-button rounded-0"
+            className="toggle-button rounded-0 timer-toggle-button"
           >
             {intl.formatMessage(messages.onLabel)}
           </Button>
@@ -668,14 +668,14 @@ export const GameEditor = ({
               <Button
                 onClick={() => setShuffleStatus(false)}
                 variant={!settings.shuffle ? 'primary' : 'outline-primary'}
-                className="toggle-button rounded-0"
+                className="toggle-button rounded-0 shuffle-toggle-button"
               >
                 {intl.formatMessage(messages.offLabel)}
               </Button>
               <Button
                 onClick={() => setShuffleStatus(true)}
                 variant={settings.shuffle ? 'primary' : 'outline-primary'}
-                className="toggle-button rounded-0"
+                className="toggle-button rounded-0 shuffle-toggle-button"
               >
                 {intl.formatMessage(messages.onLabel)}
               </Button>

--- a/src/editors/containers/GameEditor/index.scss
+++ b/src/editors/containers/GameEditor/index.scss
@@ -296,3 +296,8 @@ width: 100%;
   color: #51565C;
   margin-bottom: 8px;
 }
+
+.timer-toggle-button:focus::before,
+.shuffle-toggle-button:focus::before {
+	display: none;
+}


### PR DESCRIPTION
## Description

Removes the unwanted oval focus outline that appeared around the selected state of the Timer and Shuffle toggles in the Games editor.
Adds scoped toggle classes and suppresses the ::before focus pseudo-element to ensure consistent visual selection.

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-519