### PR TITLE
feat(invideoquiz): add validation for duplicate problem timestamps

### DIFF
--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -37,6 +37,7 @@ import { getItemIcon } from '@src/generic/block-type-utils';
 import AlertError from '@src/generic/alert-error';
 import ModalIframe from '@src/generic/modal-iframe';
 import EditorPage from '@src/editors/EditorPage';
+import supportedEditors from '@src/editors/supportedEditors';
 import DraggableList, { SortableItem as GenericSortableItem } from '@src/generic/DraggableList';
 import { ToastContext } from '@src/generic/toast-context';
 import { useUnitHandler } from './data/hooks';
@@ -208,10 +209,7 @@ const UnitCard = ({
     `${getConfig().STUDIO_BASE_URL}/xblock/${blockId}/action/edit`
   );
 
-  const supportsMFEEditor = (blockType: string): boolean => {
-    const supportedTypes = ['html', 'video', 'problem', 'video_upload', 'games'];
-    return supportedTypes.includes(blockType);
-  };
+  const supportsMFEEditor = (blockType: string): boolean => Boolean(supportedEditors[blockType]);
 
   const handleShowLegacyEditModal = (blockId: string) => {
     setEditXBlockId(blockId);

--- a/src/editors/containers/InVideoQuizEditor/index.jsx
+++ b/src/editors/containers/InVideoQuizEditor/index.jsx
@@ -102,6 +102,14 @@ export const InVideoQuizEditor = ({
       setSaveError(intl.formatMessage(messages.timeFormatError));
       return;
     }
+    const times = quizItems
+      .map((item) => item.time)
+      .filter(Boolean);
+    const hasDuplicateTimes = times.length !== new Set(times).size;
+    if (hasDuplicateTimes) {
+      setSaveError(intl.formatMessage(messages.duplicateTimeError));
+      return;
+    }
     const hasProblemWithoutTimer = quizItems.some((item) => item.problemId && !item.time);
     if (hasProblemWithoutTimer) {
       setSaveError(intl.formatMessage(messages.timerRequiredError));

--- a/src/editors/containers/InVideoQuizEditor/messages.ts
+++ b/src/editors/containers/InVideoQuizEditor/messages.ts
@@ -101,6 +101,11 @@ const messages = defineMessages({
     defaultMessage: 'Failed to parse jump back data',
     description: 'Error message when jump back JSON parsing fails.',
   },
+  duplicateTimeError: {
+    id: 'InVideoQuizEditor.duplicateTimeError',
+    defaultMessage: 'Each problem must have a unique timestamp. Please remove duplicate times.',
+    description: 'Validation error when multiple quiz items share the same time.',
+  },
   saveErrorTitle: {
     id: 'InVideoQuizEditor.saveErrorTitle',
     defaultMessage: 'Error saving in-video quiz',


### PR DESCRIPTION
## Description

- This PR adds validation in the In-Video Quiz Editor to prevent saving multiple problems with the same video timestamp. If duplicate timestamps are detected, saving is blocked and a localized error message is shown.
- It also refactors `UnitCard` to use the centralized `supportedEditors` configuration instead of a hardcoded list of block types, ensuring the correct MFE editor opens from the Outline page.

## Supporting information

- Improves data integrity and prevents conflicting quiz behavior during video playback.

## Testing instructions

- Open an In-Video Quiz in Studio.
- Add two problems with the same timestamp.
- Click Save → Saving should fail with a duplicate timestamp error.
- Update one timestamp to be unique.
- Click Save → Saving should succeed.

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-538
- https://2u-internal.atlassian.net/browse/TNL2-540

## Screenshot

<img width="1890" height="788" alt="image" src="https://github.com/user-attachments/assets/a83577db-a032-4f35-a38c-c043c245fd49" />
