### PR TITLE
fix: In-video quiz: Change text in button from 'Add to course' to 'Save'

### DIFF
--- a/src/editors/containers/InVideoQuizEditor/index.jsx
+++ b/src/editors/containers/InVideoQuizEditor/index.jsx
@@ -352,8 +352,8 @@ export const InVideoQuizEditor = ({
       returnFunction={returnFunction}
       isDirty={() => isDirty}
       onSave={handleSave}
-      saveButtonLabel={intl.formatMessage(messages.addToCourse)}
-      saveButtonAriaLabel={intl.formatMessage(messages.addToCourse)}
+      saveButtonLabel={intl.formatMessage(messages.save)}
+      saveButtonAriaLabel={intl.formatMessage(messages.save)}
     >
       <div className="editor-body h-75 overflow-auto">
         {!blockFinished ? loading : page}


### PR DESCRIPTION
## Description

 Updated the save button label in the InVideoQuiz editor from "Add to course" to "Save", using the existing messages.save message


This change impacts course authors and instructors (anyone with Studio access who can edit course content). Specifically, users with these roles:

  - Course Staff - can edit course content in Studio
  - Course Admins/Instructors - full course editing privileges
  - Global Staff - platform-wide access

  It does not impact learners — the change is purely in the Studio editor UI, not the learner-facing experience.

## Screenshot 

<img width="461" height="192" alt="Screenshot 2026-02-24 at 9 46 57 AM" src="https://github.com/user-attachments/assets/13912b0a-6b26-41af-b92a-d75b4b648b26" />


## Jira ticket 

[TNL2-542](https://2u-internal.atlassian.net/browse/TNL2-542)

## Testing instructions

  - Open the InVideoQuiz editor
  - Verify the save button displays "Save" instead of "Add to course"