### PR TITLE
fix: open editor when invideoquiz component added to unit

### DIFF
--- a/src/course-unit/__mocks__/courseSectionVertical.js
+++ b/src/course-unit/__mocks__/courseSectionVertical.js
@@ -82,6 +82,14 @@ module.exports = {
           tab: 'common',
           support_level: true,
         },
+        {
+          display_name: 'In Video Quiz',
+          category: 'invideoquiz',
+          boilerplate_name: null,
+          hinted: false,
+          tab: 'common',
+          support_level: true,
+        },
       ],
       display_name: 'Advanced',
       support_legend: {

--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -390,6 +390,38 @@ describe('<AddComponent />', () => {
     });
   });
 
+  it('calls handleCreateNewCourseXBlock with callback that opens editor when InVideoQuiz is selected from Advanced modal', async () => {
+    handleCreateNewCourseXBlockMock.mockImplementation((_params, callback) => {
+      if (callback) {
+        callback({ courseKey: 'course-v1:test', locator: 'block-v1:test+invideoquiz' });
+      }
+    });
+
+    const user = userEvent.setup();
+    const { getByRole } = renderComponent();
+    const advancedButton = getByRole('button', {
+      name: new RegExp(`${messages.buttonText.defaultMessage} Advanced`, 'i'),
+    });
+
+    await user.click(advancedButton);
+    const modalContainer = getByRole('dialog');
+
+    const radioInput = within(modalContainer).getByRole('radio', { name: 'In Video Quiz' });
+    const sendBtn = within(modalContainer).getByRole('button', { name: messages.modalBtnText.defaultMessage });
+
+    expect(sendBtn).toBeDisabled();
+    await user.click(radioInput);
+    expect(sendBtn).not.toBeDisabled();
+
+    await user.click(sendBtn);
+
+    expect(handleCreateNewCourseXBlockMock).toHaveBeenCalledWith({
+      parentLocator: '123',
+      type: COMPONENT_TYPES.invideoquiz,
+      category: COMPONENT_TYPES.invideoquiz,
+    }, expect.any(Function));
+  });
+
   it('verifies "Text" component creation and submission in modal', async () => {
     const user = userEvent.setup();
     const { getByRole } = renderComponent();

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -170,7 +170,19 @@ const AddComponent = ({
         showAddLibraryContentModal();
         break;
       case COMPONENT_TYPES.advanced:
-        handleCreateNewCourseXBlock({ type: moduleName, category: moduleName, parentLocator: blockId });
+        if (moduleName === COMPONENT_TYPES.invideoquiz) {
+          handleCreateNewCourseXBlock(
+            { type: moduleName, category: moduleName, parentLocator: blockId },
+            ({ courseKey, locator }) => {
+              setCourseId(courseKey);
+              setBlockType(moduleName);
+              setNewBlockId(locator);
+              showXBlockEditorModal();
+            },
+          );
+        } else {
+          handleCreateNewCourseXBlock({ type: moduleName, category: moduleName, parentLocator: blockId });
+        }
         break;
       case COMPONENT_TYPES.openassessment:
         handleCreateNewCourseXBlock({ boilerplate: moduleName, category: type, parentLocator: blockId });

--- a/src/generic/block-type-utils/constants.ts
+++ b/src/generic/block-type-utils/constants.ts
@@ -39,6 +39,7 @@ export const COMPONENT_TYPES = {
   video: 'video',
   dragAndDrop: 'drag-and-drop-v2',
   games: 'games',
+  invideoquiz: 'invideoquiz',
   lti: 'lti_consumer',
   scorm: 'scorm',
   h5p: 'h5pxblock',


### PR DESCRIPTION
## Description

 - When adding an in-video quiz from the Advanced component menu, the MFE editor now opens immediately after creation instead of staying on the unit page
  - Added invideoquiz to COMPONENT_TYPES constants
  - Inside the advanced case in AddComponent.tsx, invideoquiz is now created with a callback that opens the editor modal (same pattern as problem, html, games)

### Impacted users

This impacts course authors and instructors — anyone with Studio editing access who adds in-video quiz components to units. Specifically:

  - Course Staff
  - Course Admins/Instructors
  - Global Staff

### Screen recording


https://github.com/user-attachments/assets/a6ca8d67-eb78-4c1d-9631-dcdc0d4629ea



## Supporting information

Jira ticket: 
[TNL2-543](https://2u-internal.atlassian.net/browse/TNL2-543)

## Testing instructions

 - Navigate to a Unit page in Studio
  - Click "Add Component" > Advanced > In-Video Quiz
  - Verify the InVideoQuiz editor opens immediately after the component is created
  - Verify other advanced components still behave as before (no editor opens)


