### PR TITLE
feat(course-outline): open component editors in new tabs via right-click

### DIFF
--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -25,12 +25,21 @@
         display: flex;
         align-items: center;
 
-        >span.flex-grow-1 {
+        >.flex-grow-1 {
           min-width: 0;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
           max-width: 80%;
+        }
+
+        >a.flex-grow-1 {
+          color: inherit;
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
     }

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -41,6 +41,18 @@
             text-decoration: underline;
           }
         }
+
+        >a.component-card-button-icon {
+          text-decoration: none;
+          color: var(--pgn-color-primary-500);
+
+          &:hover,
+          &:focus {
+            text-decoration: none;
+            color: var(--pgn-color-white);
+            background-color: var(--pgn-color-primary-500);
+          }
+        }
       }
     }
 

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -290,45 +290,54 @@ describe('<UnitCard />', () => {
       fireEvent.click(expandButton);
     };
 
-    it('renders component names as links with correct href for MFE-supported types', async () => {
+    it('renders component names as links to the unit page', async () => {
       await setupExpandedView([htmlComponent]);
 
-      const link = await screen.findByTestId('component-editor-link');
+      const link = await screen.findByTestId('component-name-link');
       expect(link.tagName).toBe('A');
-      expect(link).toHaveAttribute('href', `/course/5/editor/html/${htmlComponent.blockId}`);
+      expect(link).toHaveAttribute('href', `/some/${unit.id}#${htmlComponent.blockId}`);
       expect(link).toHaveTextContent('HTML Component');
     });
 
-    it('renders component names as links with legacy Studio URL for non-MFE types', async () => {
+    it('renders edit button with correct href for MFE-supported types', async () => {
+      await setupExpandedView([htmlComponent]);
+
+      const editButton = await screen.findByTestId('component-edit-button');
+      expect(editButton.tagName).toBe('A');
+      expect(editButton).toHaveAttribute('href', `/course/5/editor/html/${htmlComponent.blockId}`);
+    });
+
+    it('renders edit button with legacy Studio URL for non-MFE types', async () => {
       await setupExpandedView([oraComponent]);
 
-      const link = await screen.findByTestId('component-editor-link');
-      expect(link).toHaveAttribute(
+      const editButton = await screen.findByTestId('component-edit-button');
+      const returnTo = encodeURIComponent(`${getConfig().STUDIO_BASE_URL}/container/${unit.id}`);
+      expect(editButton).toHaveAttribute(
         'href',
-        `${getConfig().STUDIO_BASE_URL}/xblock/${oraComponent.blockId}/action/edit`,
+        `${getConfig().STUDIO_BASE_URL}/xblock/${oraComponent.blockId}/action/edit?returnTo=${returnTo}`,
       );
     });
 
-    it('opens modal editor on plain left-click (does not navigate)', async () => {
+    it('opens modal editor on plain left-click on edit button (does not navigate)', async () => {
       await setupExpandedView([htmlComponent]);
 
-      const link = await screen.findByTestId('component-editor-link');
+      const editButton = await screen.findByTestId('component-edit-button');
       const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
       Object.defineProperty(clickEvent, 'metaKey', { value: false });
       Object.defineProperty(clickEvent, 'ctrlKey', { value: false });
       Object.defineProperty(clickEvent, 'button', { value: 0 });
 
-      const prevented = !link.dispatchEvent(clickEvent);
+      const prevented = !editButton.dispatchEvent(clickEvent);
       expect(prevented).toBe(true);
     });
 
-    it('allows Ctrl+click to open in new tab (does not prevent default)', async () => {
+    it('allows Ctrl+click on edit button to open in new tab (does not prevent default)', async () => {
       await setupExpandedView([htmlComponent]);
 
-      const link = await screen.findByTestId('component-editor-link');
+      const editButton = await screen.findByTestId('component-edit-button');
       const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true });
 
-      const prevented = !link.dispatchEvent(clickEvent);
+      const prevented = !editButton.dispatchEvent(clickEvent);
       expect(prevented).toBe(false);
     });
   });

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -1,6 +1,7 @@
 import {
   act, fireEvent, initializeMocks, render, screen, waitFor, within,
 } from '@src/testUtils';
+import { getConfig } from '@edx/frontend-platform';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 
 import { XBlock } from '@src/data/types';
@@ -261,5 +262,74 @@ describe('<UnitCard />', () => {
 
     expect(await screen.findByText(/unable to load unit components/i)).toBeInTheDocument();
     expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
+  });
+
+  describe('component editor links', () => {
+    const htmlComponent = {
+      blockId: 'block-v1:test+type@html+block@1',
+      blockType: 'html',
+      displayName: 'HTML Component',
+    };
+    const oraComponent = {
+      blockId: 'block-v1:test+type@openassessment+block@2',
+      blockType: 'openassessment',
+      displayName: 'ORA Component',
+    };
+
+    const setupExpandedView = async (components: any[]) => {
+      mockUseUnitHandler.mockReturnValue({
+        data: { components },
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+
+      renderComponent();
+
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+    };
+
+    it('renders component names as links with correct href for MFE-supported types', async () => {
+      await setupExpandedView([htmlComponent]);
+
+      const link = await screen.findByTestId('component-editor-link');
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', `/course/5/editor/html/${htmlComponent.blockId}`);
+      expect(link).toHaveTextContent('HTML Component');
+    });
+
+    it('renders component names as links with legacy Studio URL for non-MFE types', async () => {
+      await setupExpandedView([oraComponent]);
+
+      const link = await screen.findByTestId('component-editor-link');
+      expect(link).toHaveAttribute(
+        'href',
+        `${getConfig().STUDIO_BASE_URL}/xblock/${oraComponent.blockId}/action/edit`,
+      );
+    });
+
+    it('opens modal editor on plain left-click (does not navigate)', async () => {
+      await setupExpandedView([htmlComponent]);
+
+      const link = await screen.findByTestId('component-editor-link');
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+      Object.defineProperty(clickEvent, 'metaKey', { value: false });
+      Object.defineProperty(clickEvent, 'ctrlKey', { value: false });
+      Object.defineProperty(clickEvent, 'button', { value: 0 });
+
+      const prevented = !link.dispatchEvent(clickEvent);
+      expect(prevented).toBe(true);
+    });
+
+    it('allows Ctrl+click to open in new tab (does not prevent default)', async () => {
+      await setupExpandedView([htmlComponent]);
+
+      const link = await screen.findByTestId('component-editor-link');
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true });
+
+      const prevented = !link.dispatchEvent(clickEvent);
+      expect(prevented).toBe(false);
+    });
   });
 });

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -7,7 +7,9 @@ import {
   useState,
 } from 'react';
 import { useDispatch } from 'react-redux';
-import { useToggle, Icon, IconButtonWithTooltip } from '@openedx/paragon';
+import {
+  useToggle, Icon, OverlayTrigger, Tooltip,
+} from '@openedx/paragon';
 import { EditOutline as EditIcon } from '@openedx/paragon/icons';
 import { isEmpty } from 'lodash';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -215,7 +217,8 @@ const UnitCard = ({
     if (supportsMFEEditor(blockType)) {
       return `/course/${courseId}/editor/${blockType}/${blockId}`;
     }
-    return `${getConfig().STUDIO_BASE_URL}/xblock/${blockId}/action/edit`;
+    const returnTo = encodeURIComponent(`${getConfig().STUDIO_BASE_URL}/container/${id}`);
+    return `${getConfig().STUDIO_BASE_URL}/xblock/${blockId}/action/edit?returnTo=${returnTo}`;
   };
 
   const handleShowLegacyEditModal = (blockId: string) => {
@@ -484,6 +487,13 @@ const UnitCard = ({
                             id={component.blockId}
                             key={component.blockId}
                             buttonVariant="secondary"
+                            isClickable
+                            onClick={() => handleComponentClick(component.blockId)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                handleComponentClick(component.blockId);
+                              }
+                            }}
                             componentStyle={{
                               background: 'white',
                               borderRadius: '6px',
@@ -494,43 +504,49 @@ const UnitCard = ({
                               borderRadius: '6px 6px 0px 0px',
                               padding: '12px 16px',
                             }}
-                            isClickable
-                            onClick={() => handleComponentClick(component.blockId)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                handleComponentClick(component.blockId);
-                              }
-                            }}
                             actions={(
                               <>
                                 <Icon src={ComponentIcon} className="mr-2 text-dark" />
                                 <a
-                                  href={getComponentEditorUrl(component.blockType, component.blockId)}
+                                  href={`${getTitleLink(id)}#${component.blockId}`}
                                   className="flex-grow-1"
-                                  data-testid="component-editor-link"
+                                  data-testid="component-name-link"
                                   onClick={(e) => {
-                                    if (e.metaKey || e.ctrlKey) {
-                                      e.stopPropagation();
-                                      return;
-                                    }
-                                    e.preventDefault();
                                     e.stopPropagation();
-                                    handleComponentEdit(e, component.blockType, component.blockId);
+                                    if (!e.metaKey && !e.ctrlKey) {
+                                      e.preventDefault();
+                                      handleComponentClick(component.blockId);
+                                    }
                                   }}
                                 >
                                   {component.displayName}
                                 </a>
-                                <IconButtonWithTooltip
-                                  className="component-card-button-icon btn-icon btn-icon-primary btn-icon-md"
-                                  data-testid="component-edit-button"
-                                  alt={intl.formatMessage(messages.editComponent)}
-                                  tooltipContent={<div>{intl.formatMessage(messages.editComponent)}</div>}
-                                  iconAs={EditIcon}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleComponentEdit(e, component.blockType, component.blockId);
-                                  }}
-                                />
+                                <OverlayTrigger
+                                  placement="top"
+                                  overlay={(
+                                    <Tooltip id={`edit-tooltip-${component.blockId}`}>
+                                      {intl.formatMessage(messages.editComponent)}
+                                    </Tooltip>
+                                  )}
+                                >
+                                  <a
+                                    href={getComponentEditorUrl(component.blockType, component.blockId)}
+                                    className="component-card-button-icon btn btn-icon btn-icon-primary btn-icon-md"
+                                    data-testid="component-edit-button"
+                                    aria-label={intl.formatMessage(messages.editComponent)}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      if (!e.metaKey && !e.ctrlKey) {
+                                        e.preventDefault();
+                                        handleComponentEdit(e, component.blockType, component.blockId);
+                                      }
+                                    }}
+                                  >
+                                    <span className="btn-icon_btn-icon-primary_icon">
+                                      <Icon src={EditIcon} />
+                                    </span>
+                                  </a>
+                                </OverlayTrigger>
                               </>
                             )}
                           />

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -211,6 +211,13 @@ const UnitCard = ({
 
   const supportsMFEEditor = (blockType: string): boolean => Boolean(supportedEditors[blockType]);
 
+  const getComponentEditorUrl = (blockType: string, blockId: string): string => {
+    if (supportsMFEEditor(blockType)) {
+      return `/course/${courseId}/editor/${blockType}/${blockId}`;
+    }
+    return `${getConfig().STUDIO_BASE_URL}/xblock/${blockId}/action/edit`;
+  };
+
   const handleShowLegacyEditModal = (blockId: string) => {
     setEditXBlockId(blockId);
     setShowLegacyEditModal(true);
@@ -497,7 +504,22 @@ const UnitCard = ({
                             actions={(
                               <>
                                 <Icon src={ComponentIcon} className="mr-2 text-dark" />
-                                <span className="flex-grow-1">{component.displayName}</span>
+                                <a
+                                  href={getComponentEditorUrl(component.blockType, component.blockId)}
+                                  className="flex-grow-1"
+                                  data-testid="component-editor-link"
+                                  onClick={(e) => {
+                                    if (e.metaKey || e.ctrlKey) {
+                                      e.stopPropagation();
+                                      return;
+                                    }
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    handleComponentEdit(e, component.blockType, component.blockId);
+                                  }}
+                                >
+                                  {component.displayName}
+                                </a>
                                 <IconButtonWithTooltip
                                   className="component-card-button-icon btn-icon btn-icon-primary btn-icon-md"
                                   data-testid="component-edit-button"


### PR DESCRIPTION
## Description

Added ability to open components in a new tab.

  - Replace IconButtonWithTooltip with a native <a> tag wrapped in OverlayTrigger/Tooltip for the component edit button, enabling standard browser right-click "Open in new tab" behavior
  - Both the component name link and the edit icon link to the component editor URL, enabling right-click "Open in new tab" on either element
  - Left-clicking the component name navigates to the unit page; left-clicking the edit icon opens the editor modal inline
  - Add returnTo query parameter to legacy editor URLs so users can navigate back to the unit container after editing
  - Add styles for the new anchor-based edit button to match the existing icon button appearance
  - Fix icon container class name to use correct Paragon convention (btn-icon__icon-container)
  - Replace hardcoded color with CSS variable for theming consistency

## Jira ticket

[TNL2-532](https://2u-internal.atlassian.net/browse/TNL2-532)

## Screen recording


https://github.com/user-attachments/assets/a2c5490a-fbff-40c5-8853-adc989411dbe



## Testing instructions

  - Expand a unit in the course outline
  - Verify left-clicking a component name navigates to the unit page
  - Verify left-clicking the edit (pencil) icon opens the editor modal
  - Verify Ctrl/Cmd+click or right-click "Open in new tab" on the component name opens the editor in a new tab
  - Verify Ctrl/Cmd+click or right-click "Open in new tab" on the edit icon opens the editor in a new tab
  - Verify the edit button tooltip still appears on hover
  - Verify legacy (non-MFE) editor URLs include the returnTo parameter




