### PR TITLE
fix: hints input box too narrow in problem editor settings sidebar

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.jsx
@@ -23,6 +23,7 @@ const HintsCard = ({
 
   return (
     <SettingsOption
+      className="hints-card"
       title={intl.formatMessage(messages.hintSettingTitle)}
       summary={intl.formatMessage(summary.message, { ...summary.values })}
       none={!hints.length}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
@@ -18,6 +18,10 @@
     }
   }
 
+  .settingsOption.hints-card {
+    align-items: stretch;
+  }
+
   .settingsOption {
     .pgn__form-checkbox .pgn__form-label {
       min-width: .8rem;


### PR DESCRIPTION
## Description

 - Fix the hints input box being too narrow in the Problem Editor settings sidebar by adding align-items: stretch scoped to only the Hints card (.settingsOption.hints-card)
  - The Paragon Card component inherits Bootstrap's .card default of align-items: flex-start, which caused the TinyMCE hint input to not fill the available sidebar width
  - The fix is scoped to HintsCard only (via a hints-card className) to avoid unintended layout changes to other settings cards (Type, Scoring, Show answer, etc.)


## Screenshot 

### Before
<img width="1707" height="1024" alt="Screenshot 2026-03-11 at 6 27 19 PM" src="https://github.com/user-attachments/assets/98c776d7-2e76-4021-ae89-097e725836cb" />

### After fix

<img width="1698" height="1033" alt="Screenshot 2026-03-11 at 6 24 08 PM" src="https://github.com/user-attachments/assets/514b4a58-2d75-456b-823b-81d73b18c939" />


## Supporting information

Jira ticket : [TNL2-557](https://2u-internal.atlassian.net/browse/TNL2-557)

## Testing instructions

  - Open a Problem Editor (any problem type that supports hints)
  - Expand the Hints section in the settings sidebar
  - Click Add hint and verify the hint input box stretches to fill the full width of the sidebar
  - Verify other settings cards (Type, Scoring, Show answer, Show reset option) are visually unchanged
  - Test with multiple hints added to ensure all hint rows render at full width
  
