### PR TITLE
fix: resolve issue with Xpert unit summary toggle not updating state

### DIFF
--- a/plugins/course-apps/xpert_unit_summary/Settings.jsx
+++ b/plugins/course-apps/xpert_unit_summary/Settings.jsx
@@ -25,7 +25,7 @@ const XpertUnitSummarySettings = () => {
 
   return (
     <SettingsModal
-      appId="xpert-unit-summary"
+      appId="xpert_unit_summary"
       title={intl.formatMessage(messages.heading)}
       enableAppHelp={intl.formatMessage(messages.enableXpertUnitSummaryHelp)}
       helpPrivacyText={intl.formatMessage(messages.enableXpertUnitSummaryHelpPrivacyLink)}

--- a/plugins/course-apps/xpert_unit_summary/Settings.test.jsx
+++ b/plugins/course-apps/xpert_unit_summary/Settings.test.jsx
@@ -107,7 +107,7 @@ describe('XpertUnitSummarySettings', () => {
 
     test('Shows switch on if enabled from backend', async () => {
       const enableBadge = await findByTestId(container, 'enable-badge');
-      expect(container.querySelector('#enable-xpert-unit-summary-toggle').checked).toBeTruthy();
+      expect(container.querySelector('#enable-xpert_unit_summary-toggle').checked).toBeTruthy();
       expect(enableBadge).toBeTruthy();
     });
 
@@ -119,13 +119,13 @@ describe('XpertUnitSummarySettings', () => {
         }));
 
       renderComponent();
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
-      expect(container.querySelector('#enable-xpert-unit-summary-toggle').checked).toBeTruthy();
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
+      expect(container.querySelector('#enable-xpert_unit_summary-toggle').checked).toBeTruthy();
       expect(queryByTestId(container, 'enable-badge')).toBeTruthy();
     });
 
     test('Shows enable radio selected if enabled from backend', async () => {
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       expect(queryByTestId(container, 'enable-radio').checked).toBeTruthy();
     });
 
@@ -137,7 +137,7 @@ describe('XpertUnitSummarySettings', () => {
         }));
 
       renderComponent();
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       expect(queryByTestId(container, 'disable-radio').checked).toBeTruthy();
     });
   });
@@ -154,8 +154,8 @@ describe('XpertUnitSummarySettings', () => {
     });
 
     test('Does not show as enabled if configuration does not exist', async () => {
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
-      expect(container.querySelector('#enable-xpert-unit-summary-toggle').checked).not.toBeTruthy();
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
+      expect(container.querySelector('#enable-xpert_unit_summary-toggle').checked).not.toBeTruthy();
       expect(queryByTestId(container, 'enable-badge')).not.toBeTruthy();
     });
   });
@@ -180,11 +180,11 @@ describe('XpertUnitSummarySettings', () => {
     test('Saving configuration changes', async () => {
       jest.spyOn(API, 'postXpertSettings');
 
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       expect(queryByTestId(container, 'disable-radio').checked).toBeTruthy();
       fireEvent.click(queryByTestId(container, 'enable-radio'));
       fireEvent.click(getByText(container, 'Save'));
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       expect(API.postXpertSettings).toBeCalled();
     });
   });
@@ -226,10 +226,10 @@ describe('XpertUnitSummarySettings', () => {
     test('Deleting course configuration', async () => {
       jest.spyOn(API, 'deleteXpertSettings');
 
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
-      fireEvent.click(container.querySelector('#enable-xpert-unit-summary-toggle'));
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
+      fireEvent.click(container.querySelector('#enable-xpert_unit_summary-toggle'));
       fireEvent.click(getByText(container, 'Save'));
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       expect(API.deleteXpertSettings).toBeCalled();
     });
   });
@@ -252,7 +252,7 @@ describe('XpertUnitSummarySettings', () => {
 
       jest.spyOn(API, 'postXpertSettings');
 
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       fireEvent.click(queryByTestId(container, 'reset-units'));
       expect(API.postXpertSettings).toBeCalledWith(courseId, { reset: true, enabled: true });
     });
@@ -274,7 +274,7 @@ describe('XpertUnitSummarySettings', () => {
 
       jest.spyOn(API, 'postXpertSettings');
 
-      await waitFor(() => expect(container.querySelector('#enable-xpert-unit-summary-toggle')).toBeTruthy());
+      await waitFor(() => expect(container.querySelector('#enable-xpert_unit_summary-toggle')).toBeTruthy());
       fireEvent.click(queryByTestId(container, 'reset-units'));
       expect(API.postXpertSettings).toBeCalledWith(courseId, { reset: true, enabled: false });
     });

--- a/plugins/course-apps/xpert_unit_summary/appInfo.js
+++ b/plugins/course-apps/xpert_unit_summary/appInfo.js
@@ -1,5 +1,5 @@
 export default {
-  id: 'xpert-unit-summary',
+  id: 'xpert_unit_summary',
   enabled: false,
   name: 'Xpert unit summaries',
   description: 'Use generative AI to summarize course content and reinforce learning.',

--- a/plugins/course-apps/xpert_unit_summary/data/thunks.js
+++ b/plugins/course-apps/xpert_unit_summary/data/thunks.js
@@ -13,7 +13,7 @@ export function updateXpertSettings(courseId, state) {
       const { response } = await postXpertSettings(courseId, state);
       const { success } = response;
       if (success) {
-        dispatch(updateModel({ modelType: 'XpertSettings', model: { id: 'xpert-unit-summary', enabled: state.enabled } }));
+        dispatch(updateModel({ modelType: 'XpertSettings', model: { id: 'xpert_unit_summary', enabled: state.enabled } }));
         dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
         return true;
       }
@@ -40,7 +40,7 @@ export function fetchXpertPluginConfigurable(courseId) {
     dispatch(addModel({
       modelType: 'XpertSettings.enabled',
       model: {
-        id: 'xpert-unit-summary',
+        id: 'xpert_unit_summary',
         enabled,
       },
     }));
@@ -62,7 +62,7 @@ export function fetchXpertSettings(courseId) {
     dispatch(addModel({
       modelType: 'XpertSettings',
       model: {
-        id: 'xpert-unit-summary',
+        id: 'xpert_unit_summary',
         enabled,
       },
     }));
@@ -79,7 +79,7 @@ export function removeXpertSettings(courseId) {
       const { response } = await deleteXpertSettings(courseId);
       const { success } = response;
       if (success) {
-        const model = { id: 'xpert-unit-summary', enabled: undefined };
+        const model = { id: 'xpert_unit_summary', enabled: undefined };
         dispatch(updateModel({ modelType: 'XpertSettings', model }));
         dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
         return true;


### PR DESCRIPTION
## Description

 Xpert Unit Summary toggle in Pages & Resources doesn't toggle between enable/disable . 
 
 ### Cause
 
Frontend still uses uses 'xpert-unit-summary' while backend is changed to return 'xpert_unit_summary'.

### Ticket

[COSMO2-841](https://2u-internal.atlassian.net/browse/COSMO2-841)