### PR TITLE
feat: add components from Outline page

### DIFF
--- a/src/course-outline/card-header/CardHeader.tsx
+++ b/src/course-outline/card-header/CardHeader.tsx
@@ -47,6 +47,7 @@ interface CardHeaderProps {
   onClickDuplicate: () => void;
   onClickMoveUp: () => void;
   onClickMoveDown: () => void;
+  onClickPreview?: () => void;
   onClickCopy?: () => void;
   titleComponent: ReactNode;
   namePrefix: string;
@@ -89,6 +90,7 @@ const CardHeader = ({
   onClickDuplicate,
   onClickMoveUp,
   onClickMoveDown,
+  onClickPreview,
   onClickCopy,
   titleComponent,
   namePrefix,
@@ -220,6 +222,14 @@ const CardHeader = ({
               iconAs={Icon}
             />
             <Dropdown.Menu>
+              {isVertical && onClickPreview && (
+                <Dropdown.Item
+                  data-testid={`${namePrefix}-card-header__menu-preview-button`}
+                  onClick={onClickPreview}
+                >
+                  {intl.formatMessage(messages.menuPreview)}
+                </Dropdown.Item>
+              )}
               {isSequential && proctoringExamConfigurationLink && (
                 <Dropdown.Item
                   as={Hyperlink}

--- a/src/course-outline/card-header/messages.js
+++ b/src/course-outline/card-header/messages.js
@@ -37,6 +37,10 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.card.button.edit.alt',
     defaultMessage: 'Rename',
   },
+  menuPreview: {
+    id: 'course-authoring.course-outline.card.menu.preview',
+    defaultMessage: 'Preview',
+  },
   menuPublish: {
     id: 'course-authoring.course-outline.card.menu.publish',
     defaultMessage: 'Publish',

--- a/src/course-outline/unit-card/AddComponentWidget.test.tsx
+++ b/src/course-outline/unit-card/AddComponentWidget.test.tsx
@@ -1,0 +1,283 @@
+import {
+  act, fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+
+import AddComponentWidget from './AddComponentWidget';
+import type { ComponentTemplate } from './data/api';
+import messages from './messages';
+
+// Mock the useCreateXBlockInUnit hook
+const mockCreateXBlock = jest.fn();
+jest.mock('./data/hooks', () => ({
+  useUnitHandler: jest.fn(() => ({
+    data: undefined, isLoading: false, isError: false, error: null,
+  })),
+  useCreateXBlockInUnit: () => ({
+    mutateAsync: mockCreateXBlock,
+    isPending: false,
+  }),
+}));
+
+// Sample component templates matching the API shape
+const htmlTemplate: ComponentTemplate = {
+  type: 'html',
+  displayName: 'Text',
+  templates: [
+    { displayName: 'Text', category: 'html', boilerplateName: undefined },
+  ],
+  supportLegend: {},
+};
+
+const problemTemplate: ComponentTemplate = {
+  type: 'problem',
+  displayName: 'Problem',
+  templates: [
+    { displayName: 'Blank Problem', category: 'problem', boilerplateName: undefined },
+    { displayName: 'Multiple Choice', category: 'problem', boilerplateName: 'multiple_choice' },
+    { displayName: 'Checkboxes', category: 'problem', boilerplateName: 'checkboxes' },
+  ],
+  supportLegend: {},
+};
+
+const advancedTemplate: ComponentTemplate = {
+  type: 'advanced',
+  displayName: 'Advanced',
+  templates: [
+    { displayName: 'LTI Consumer', category: 'lti_consumer', supportLevel: 'fs' },
+    { displayName: 'Poll', category: 'poll', supportLevel: 'ps' },
+    { displayName: 'Custom XBlock', category: 'custom_xblock', supportLevel: 'us' },
+  ],
+  supportLegend: {},
+};
+
+const unitId = 'block-v1:edX+Demo+2025+type@vertical+block@unit1';
+
+const renderWidget = (props?: Partial<React.ComponentProps<typeof AddComponentWidget>>) => render(
+  <AddComponentWidget
+    unitId={unitId}
+    componentTemplates={[htmlTemplate, problemTemplate, advancedTemplate]}
+    {...props}
+  />,
+);
+
+describe('<AddComponentWidget />', () => {
+  let mockShowToast: ReturnType<typeof initializeMocks>['mockShowToast'];
+
+  beforeEach(() => {
+    const mocks = initializeMocks();
+    mockShowToast = mocks.mockShowToast;
+    mockCreateXBlock.mockReset();
+    // Default: creation succeeds
+    mockCreateXBlock.mockResolvedValue({ locator: 'block-v1:new', courseKey: 'course-v1:test' });
+  });
+
+  it('renders the Add Component dropdown button', () => {
+    renderWidget();
+    // The toggle button should be visible with the correct label
+    expect(screen.getByText(messages.addComponentButton.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('returns null when there are no templates and no paste option', () => {
+    renderWidget({ componentTemplates: [], showPasteXBlock: false });
+    // Widget should render nothing – no dropdown visible
+    expect(screen.queryByTestId('add-component-dropdown')).not.toBeInTheDocument();
+  });
+
+  it('renders normal and advanced template items in the dropdown', async () => {
+    renderWidget();
+    // Open the dropdown menu
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+
+    // Normal templates
+    expect(screen.getByTestId('add-component-item-html')).toBeInTheDocument();
+    expect(screen.getByTestId('add-component-item-problem')).toBeInTheDocument();
+
+    // Advanced section header + items
+    expect(screen.getByText('Advanced')).toBeInTheDocument();
+    expect(screen.getByTestId('add-component-item-advanced-lti_consumer')).toBeInTheDocument();
+    expect(screen.getByTestId('add-component-item-advanced-poll')).toBeInTheDocument();
+    expect(screen.getByTestId('add-component-item-advanced-custom_xblock')).toBeInTheDocument();
+  });
+
+  it('shows support level labels for partially and not supported advanced xblocks', async () => {
+    renderWidget();
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+
+    // LTI Consumer (fs) - no support label
+    const ltiItem = screen.getByTestId('add-component-item-advanced-lti_consumer');
+    expect(ltiItem).not.toHaveTextContent(messages.supportPartiallySuppported.defaultMessage);
+    expect(ltiItem).not.toHaveTextContent(messages.supportNotSupported.defaultMessage);
+
+    // Poll (ps) - partially supported label
+    const pollItem = screen.getByTestId('add-component-item-advanced-poll');
+    expect(pollItem).toHaveTextContent(messages.supportPartiallySuppported.defaultMessage);
+
+    // Custom XBlock (us) - not supported label
+    const customItem = screen.getByTestId('add-component-item-advanced-custom_xblock');
+    expect(customItem).toHaveTextContent(messages.supportNotSupported.defaultMessage);
+  });
+
+  it('creates a single-template component directly on click', async () => {
+    const onCreated = jest.fn();
+    renderWidget({ onComponentCreated: onCreated });
+
+    // Open dropdown and click HTML (single template)
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-html')));
+
+    // Should call createXBlock with correct params
+    await waitFor(() => {
+      expect(mockCreateXBlock).toHaveBeenCalledWith({
+        parentLocator: unitId,
+        type: 'html',
+        category: 'html',
+        boilerplate: undefined,
+      });
+    });
+
+    // Should call onComponentCreated with the result
+    expect(onCreated).toHaveBeenCalledWith({
+      locator: 'block-v1:new',
+      courseKey: 'course-v1:test',
+      type: 'html',
+      category: 'html',
+    });
+  });
+
+  it('opens template selection modal for multi-template types', async () => {
+    renderWidget();
+    // Open dropdown and click Problem (multiple templates)
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-problem')));
+
+    // Modal should appear with radio options
+    expect(screen.getByText('Add problem component')).toBeInTheDocument();
+    expect(screen.getByText('Blank Problem')).toBeInTheDocument();
+    expect(screen.getByText('Multiple Choice')).toBeInTheDocument();
+    expect(screen.getByText('Checkboxes')).toBeInTheDocument();
+  });
+
+  it('creates component from modal after selecting a template', async () => {
+    const onCreated = jest.fn();
+    renderWidget({ onComponentCreated: onCreated });
+
+    // Open dropdown → click Problem → modal opens
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-problem')));
+
+    // Select "Multiple Choice" radio button
+    const multipleChoiceRadio = screen.getByLabelText('Multiple Choice');
+    await act(async () => fireEvent.click(multipleChoiceRadio));
+
+    // Click "Select" button to submit
+    const selectButton = screen.getByText(messages.templateModalSelect.defaultMessage);
+    await act(async () => fireEvent.click(selectButton));
+
+    // Should create with the selected boilerplate
+    await waitFor(() => {
+      expect(mockCreateXBlock).toHaveBeenCalledWith({
+        parentLocator: unitId,
+        type: 'problem',
+        category: 'problem',
+        boilerplate: 'multiple_choice',
+      });
+    });
+  });
+
+  it('closes modal without creating when cancel is clicked', async () => {
+    renderWidget();
+    // Open dropdown → click Problem → modal opens
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-problem')));
+
+    // Click "Cancel" button
+    const cancelButton = screen.getByText(messages.templateModalCancel.defaultMessage);
+    await act(async () => fireEvent.click(cancelButton));
+
+    // Modal should close, createXBlock should not be called
+    expect(screen.queryByText('Add problem component')).not.toBeInTheDocument();
+    expect(mockCreateXBlock).not.toHaveBeenCalled();
+  });
+
+  it('creates advanced component directly on click', async () => {
+    const onCreated = jest.fn();
+    renderWidget({ onComponentCreated: onCreated });
+
+    // Open dropdown and click an advanced item
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-advanced-poll')));
+
+    // Should create with type 'advanced' and the correct category
+    await waitFor(() => {
+      expect(mockCreateXBlock).toHaveBeenCalledWith({
+        parentLocator: unitId,
+        type: 'advanced',
+        category: 'poll',
+        boilerplate: undefined,
+      });
+    });
+  });
+
+  it('shows error toast when creation fails', async () => {
+    // Make createXBlock reject
+    mockCreateXBlock.mockRejectedValueOnce(new Error('Network error'));
+
+    renderWidget();
+
+    // Open dropdown and click HTML
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-html')));
+
+    // Should show error toast
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(messages.addComponentError.defaultMessage);
+    });
+  });
+
+  it('renders paste component option when showPasteXBlock is true', async () => {
+    const onPaste = jest.fn();
+    renderWidget({ showPasteXBlock: true, onPasteComponent: onPaste });
+
+    // Open the dropdown
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+
+    // Paste item should be visible
+    const pasteItem = screen.getByTestId('add-component-item-paste');
+    expect(pasteItem).toBeInTheDocument();
+    expect(pasteItem).toHaveTextContent(messages.pasteComponent.defaultMessage);
+
+    // Click paste
+    await act(async () => fireEvent.click(pasteItem));
+    expect(onPaste).toHaveBeenCalled();
+  });
+
+  it('does not render paste option when showPasteXBlock is false', async () => {
+    renderWidget({ showPasteXBlock: false });
+
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+
+    expect(screen.queryByTestId('add-component-item-paste')).not.toBeInTheDocument();
+  });
+
+  it('disables the Select button in modal when no template is selected', async () => {
+    renderWidget();
+    // Open dropdown → click Problem → modal opens
+    const toggle = screen.getByText(messages.addComponentButton.defaultMessage);
+    await act(async () => fireEvent.click(toggle));
+    await act(async () => fireEvent.click(screen.getByTestId('add-component-item-problem')));
+
+    // Select button should be disabled initially (no radio selected)
+    const selectButton = screen.getByText(messages.templateModalSelect.defaultMessage);
+    expect(selectButton).toBeDisabled();
+  });
+});

--- a/src/course-outline/unit-card/AddComponentWidget.test.tsx
+++ b/src/course-outline/unit-card/AddComponentWidget.test.tsx
@@ -107,12 +107,12 @@ describe('<AddComponentWidget />', () => {
 
     // LTI Consumer (fs) - no support label
     const ltiItem = screen.getByTestId('add-component-item-advanced-lti_consumer');
-    expect(ltiItem).not.toHaveTextContent(messages.supportPartiallySuppported.defaultMessage);
+    expect(ltiItem).not.toHaveTextContent(messages.supportPartiallySupported.defaultMessage);
     expect(ltiItem).not.toHaveTextContent(messages.supportNotSupported.defaultMessage);
 
     // Poll (ps) - partially supported label
     const pollItem = screen.getByTestId('add-component-item-advanced-poll');
-    expect(pollItem).toHaveTextContent(messages.supportPartiallySuppported.defaultMessage);
+    expect(pollItem).toHaveTextContent(messages.supportPartiallySupported.defaultMessage);
 
     // Custom XBlock (us) - not supported label
     const customItem = screen.getByTestId('add-component-item-advanced-custom_xblock');

--- a/src/course-outline/unit-card/AddComponentWidget.tsx
+++ b/src/course-outline/unit-card/AddComponentWidget.tsx
@@ -83,7 +83,7 @@ const AddComponentWidget = ({
   };
 
   /** Handle clicking a dropdown item – open modal if multiple templates, otherwise create directly */
-  const handleDropdownItemClick = (template: ComponentTemplate) => {
+  const handleDropdownItemClick = async (template: ComponentTemplate) => {
     if (template.templates.length > 1) {
       // Multiple sub-types available – show selection modal
       setModalTemplate(template);
@@ -92,7 +92,7 @@ const AddComponentWidget = ({
     } else {
       // Single template – create immediately
       const firstTemplate = template.templates[0];
-      handleAddComponent(
+      await handleAddComponent(
         template.type,
         firstTemplate?.category || template.type,
         firstTemplate?.boilerplateName,
@@ -101,7 +101,7 @@ const AddComponentWidget = ({
   };
 
   /** Submit the modal – create the xblock with the selected template */
-  const handleModalSubmit = () => {
+  const handleModalSubmit = async () => {
     if (!modalTemplate || !selectedTemplateValue) {
       return;
     }
@@ -110,7 +110,7 @@ const AddComponentWidget = ({
       (tpl) => (tpl.boilerplateName || tpl.category) === selectedTemplateValue,
     );
     if (selected) {
-      handleAddComponent(
+      await handleAddComponent(
         modalTemplate.type,
         selected.category || modalTemplate.type,
         selected.boilerplateName,
@@ -153,7 +153,7 @@ const AddComponentWidget = ({
       return null;
     }
     if (supportLevel === 'ps') {
-      return intl.formatMessage(messages.supportPartiallySuppported);
+      return intl.formatMessage(messages.supportPartiallySupported);
     }
     return intl.formatMessage(messages.supportNotSupported);
   };

--- a/src/course-outline/unit-card/AddComponentWidget.tsx
+++ b/src/course-outline/unit-card/AddComponentWidget.tsx
@@ -1,0 +1,298 @@
+import { useContext, useMemo, useState } from 'react';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  ActionRow,
+  Button,
+  Dropdown,
+  Form,
+  Icon,
+  Spinner,
+  StandardModal,
+} from '@openedx/paragon';
+import { Add as AddIcon, ArrowDropDown as ArrowDropDownIcon } from '@openedx/paragon/icons';
+
+import { ToastContext } from '@src/generic/toast-context';
+import type { ComponentTemplate } from './data/api';
+import { useCreateXBlockInUnit } from './data/hooks';
+import messages from './messages';
+
+/** Result returned after a component is created */
+export interface CreatedXBlockInfo {
+  locator: string;
+  courseKey: string;
+  type: string;
+  category?: string;
+}
+
+interface AddComponentWidgetProps {
+  /** Usage key of the parent unit (vertical) */
+  unitId: string;
+  /** Available component templates from the unit handler API */
+  componentTemplates: ComponentTemplate[];
+  /** Whether clipboard paste is available */
+  showPasteXBlock?: boolean;
+  /** Handler for pasting clipboard content into this unit */
+  onPasteComponent?: () => void;
+  /** Called after a component is created — receives creation info so caller can open the editor */
+  onComponentCreated?: (info: CreatedXBlockInfo) => void;
+}
+
+/**
+ * Dropdown button for adding a new component to a unit from the course outline.
+ * Shows a template selection modal (radio buttons) when a component type has multiple templates.
+ * After creation, returns the new block locator/courseKey/type via onComponentCreated callback.
+ */
+const AddComponentWidget = ({
+  unitId,
+  componentTemplates,
+  showPasteXBlock = false,
+  onPasteComponent,
+  onComponentCreated,
+}: AddComponentWidgetProps) => {
+  const intl = useIntl();
+  const { showToast } = useContext(ToastContext);
+  const { mutateAsync: createXBlock, isPending } = useCreateXBlockInUnit(unitId);
+
+  // State for template selection modal – shown when a component type has multiple templates
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  // The component template group currently being shown in the modal
+  const [modalTemplate, setModalTemplate] = useState<ComponentTemplate | null>(null);
+  // The selected radio value (boilerplateName or category) inside the modal
+  const [selectedTemplateValue, setSelectedTemplateValue] = useState<string>('');
+
+  /** Create the xblock and notify the parent with the result */
+  const handleAddComponent = async (type: string, category?: string, boilerplate?: string) => {
+    try {
+      // POST to /xblock/ and receive the new block locator + courseKey
+      const result = await createXBlock({
+        parentLocator: unitId,
+        type,
+        category,
+        boilerplate,
+      });
+      // Notify parent with creation info so it can refresh and open the editor
+      onComponentCreated?.({
+        locator: result.locator,
+        courseKey: result.courseKey,
+        type,
+        category,
+      });
+    } catch {
+      showToast(intl.formatMessage(messages.addComponentError));
+    }
+  };
+
+  /** Handle clicking a dropdown item – open modal if multiple templates, otherwise create directly */
+  const handleDropdownItemClick = (template: ComponentTemplate) => {
+    if (template.templates.length > 1) {
+      // Multiple sub-types available – show selection modal
+      setModalTemplate(template);
+      setSelectedTemplateValue('');
+      setIsModalOpen(true);
+    } else {
+      // Single template – create immediately
+      const firstTemplate = template.templates[0];
+      handleAddComponent(
+        template.type,
+        firstTemplate?.category || template.type,
+        firstTemplate?.boilerplateName,
+      );
+    }
+  };
+
+  /** Submit the modal – create the xblock with the selected template */
+  const handleModalSubmit = () => {
+    if (!modalTemplate || !selectedTemplateValue) {
+      return;
+    }
+    // Find the matching template entry from the selected radio value
+    const selected = modalTemplate.templates.find(
+      (tpl) => (tpl.boilerplateName || tpl.category) === selectedTemplateValue,
+    );
+    if (selected) {
+      handleAddComponent(
+        modalTemplate.type,
+        selected.category || modalTemplate.type,
+        selected.boilerplateName,
+      );
+    }
+    // Close the modal
+    setIsModalOpen(false);
+    setModalTemplate(null);
+    setSelectedTemplateValue('');
+  };
+
+  /** Close the modal without creating anything */
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setModalTemplate(null);
+    setSelectedTemplateValue('');
+  };
+
+  // Split templates into normal components and advanced components
+  const { normalTemplates, advancedTemplate } = useMemo(() => {
+    const normal: ComponentTemplate[] = [];
+    let advanced: ComponentTemplate | undefined;
+    componentTemplates.forEach((tpl) => {
+      if (!tpl.templates || tpl.templates.length === 0) {
+        return;
+      }
+      if (tpl.type === 'advanced') {
+        advanced = tpl;
+      } else {
+        normal.push(tpl);
+      }
+    });
+    return { normalTemplates: normal, advancedTemplate: advanced };
+  }, [componentTemplates]);
+
+  // Resolve the support level label for advanced xblock items
+  // fs/true = fully supported (no label), ps = partially supported, us/other = not supported
+  const getSupportLabel = (supportLevel?: string | boolean): string | null => {
+    if (supportLevel === true || supportLevel === 'fs') {
+      return null;
+    }
+    if (supportLevel === 'ps') {
+      return intl.formatMessage(messages.supportPartiallySuppported);
+    }
+    return intl.formatMessage(messages.supportNotSupported);
+  };
+
+  if (normalTemplates.length === 0 && !advancedTemplate && !showPasteXBlock) {
+    return null;
+  }
+
+  return (
+    <>
+      <Dropdown id={`add-component-${unitId}`} data-testid="add-component-dropdown">
+        <Dropdown.Toggle
+          id={`add-component-toggle-${unitId}`}
+          variant="tertiary"
+          size="sm"
+          className="add-component-toggle w-100 bg-white text-dark-700 small rounded shadow-none"
+          disabled={isPending}
+        >
+          <span className="d-flex align-items-center w-100">
+            {isPending ? (
+              <Spinner animation="border" size="sm" className="mr-2" />
+            ) : (
+              <Icon src={AddIcon} className="mr-2" />
+            )}
+            <span>{intl.formatMessage(messages.addComponentButton)}</span>
+            <Icon src={ArrowDropDownIcon} className="ml-auto" />
+          </span>
+        </Dropdown.Toggle>
+        <Dropdown.Menu className="add-component-dropdown-menu w-100 overflow-auto border border-light-400 shadow-sm">
+          {/* Paste component – shown when clipboard has a pasteable xblock */}
+          {showPasteXBlock && onPasteComponent && (
+            <>
+              <Dropdown.Item
+                onClick={onPasteComponent}
+                disabled={isPending}
+                className="d-flex justify-content-between align-items-center pt-3 pb-2"
+                data-testid="add-component-item-paste"
+              >
+                {intl.formatMessage(messages.pasteComponent)}
+              </Dropdown.Item>
+              <Dropdown.Divider />
+            </>
+          )}
+
+          {/* Normal component types – opens modal if multiple templates, else creates directly */}
+          {normalTemplates.map((template) => (
+            <Dropdown.Item
+              key={template.type}
+              onClick={() => handleDropdownItemClick(template)}
+              disabled={isPending}
+              data-testid={`add-component-item-${template.type}`}
+            >
+              {template.displayName}
+            </Dropdown.Item>
+          ))}
+
+          {/* Advanced section: header + individual advanced xblock templates */}
+          {advancedTemplate && (
+            <>
+              <Dropdown.Header className="x-small font-weight-normal text-gray-500 mt-1">
+                {advancedTemplate.displayName}
+              </Dropdown.Header>
+              {advancedTemplate.templates.map((tpl) => {
+                const supportLabel = getSupportLabel(tpl.supportLevel);
+                return (
+                  <Dropdown.Item
+                    key={`advanced-${tpl.category}-${tpl.boilerplateName || 'default'}`}
+                    onClick={() => handleAddComponent(
+                      'advanced',
+                      tpl.category || 'advanced',
+                      tpl.boilerplateName,
+                    )}
+                    disabled={isPending}
+                    data-testid={`add-component-item-advanced-${tpl.category}`}
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span>{tpl.displayName}</span>
+                    {supportLabel && (
+                      <span className="text-nowrap shrink-0 text-muted small ml-3">
+                        {supportLabel}
+                      </span>
+                    )}
+                  </Dropdown.Item>
+                );
+              })}
+            </>
+          )}
+        </Dropdown.Menu>
+      </Dropdown>
+
+      {/* Template selection modal – shown when a component type has multiple sub-templates */}
+      {modalTemplate && (
+        <StandardModal
+          title={intl.formatMessage(messages.templateModalTitle, {
+            componentTitle: (modalTemplate.displayName ?? '').toLowerCase(),
+          })}
+          isOpen={isModalOpen}
+          onClose={handleModalClose}
+          size="md"
+          footerNode={(
+            <ActionRow>
+              <ActionRow.Spacer />
+              <Button variant="tertiary" onClick={handleModalClose}>
+                {intl.formatMessage(messages.templateModalCancel)}
+              </Button>
+              <Button
+                onClick={handleModalSubmit}
+                disabled={!selectedTemplateValue || isPending}
+              >
+                {intl.formatMessage(messages.templateModalSelect)}
+              </Button>
+            </ActionRow>
+          )}
+        >
+          <Form.Group>
+            <Form.RadioSet
+              name={modalTemplate.displayName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSelectedTemplateValue(e.target.value)}
+            >
+              {modalTemplate.templates.map((tpl) => {
+                // Radio value is boilerplateName or category – matches how course-unit modal works
+                const value = tpl.boilerplateName || tpl.category || '';
+                return (
+                  <div
+                    key={tpl.displayName}
+                    className="d-flex justify-content-between w-100 mb-2 align-items-end"
+                  >
+                    <Form.Radio value={value}>
+                      {tpl.displayName}
+                    </Form.Radio>
+                  </div>
+                );
+              })}
+            </Form.RadioSet>
+          </Form.Group>
+        </StandardModal>
+      )}
+    </>
+  );
+};
+
+export default AddComponentWidget;

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -93,5 +93,22 @@
         }
       }
     }
+
+    /* Add Component dropdown button and menu –
+       sized to match the xblock component cards above */
+
+    .add-component-toggle {
+      border: 1px solid var(--pgn-color-light-400);
+      padding: 20px 16px;
+
+      // Hide the default Paragon caret since we render our own ArrowDropDown icon
+      &::after {
+        display: none;
+      }
+    }
+
+    .add-component-dropdown-menu {
+      max-height: 400px;
+    }
   }
 }

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -12,6 +12,7 @@ import componentMessages from './messages';
 const mockUseAcceptLibraryBlockChanges = jest.fn();
 const mockUseIgnoreLibraryBlockChanges = jest.fn();
 const mockUseUnitHandler = jest.fn();
+const mockUseComponentTemplates = jest.fn();
 const mockCreateXBlock = jest.fn();
 const mockPasteBlock = jest.fn();
 const mockCopyToClipboard = jest.fn();
@@ -28,6 +29,7 @@ jest.mock('@src/course-unit/data/apiHooks', () => ({
 
 jest.mock('./data/hooks', () => ({
   useUnitHandler: (...args: unknown[]) => mockUseUnitHandler(...args),
+  useComponentTemplates: (...args: unknown[]) => mockUseComponentTemplates(...args),
   useCreateXBlockInUnit: () => ({
     mutateAsync: mockCreateXBlock,
     isPending: false,
@@ -159,6 +161,8 @@ describe('<UnitCard />', () => {
     mockUseUnitHandler.mockReturnValue({
       data: undefined, isLoading: false, isError: false, error: null, refetch: jest.fn(),
     });
+    mockUseComponentTemplates.mockReset();
+    mockUseComponentTemplates.mockReturnValue({ data: undefined });
     mockPasteBlock.mockReset();
     mockCreateXBlock.mockReset();
     mockShowPasteXBlock.current = false;
@@ -431,12 +435,13 @@ describe('<UnitCard />', () => {
     it('renders AddComponentWidget when enableOutlineComponentCreation flag is true', async () => {
       mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
       mockUseUnitHandler.mockReturnValue({
-        data: { components: [], componentTemplates },
+        data: { components: [] },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
       });
+      mockUseComponentTemplates.mockReturnValue({ data: componentTemplates });
 
       renderComponent();
 
@@ -450,12 +455,13 @@ describe('<UnitCard />', () => {
     it('hides AddComponentWidget when enableOutlineComponentCreation flag is false', async () => {
       mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: false });
       mockUseUnitHandler.mockReturnValue({
-        data: { components: [], componentTemplates },
+        data: { components: [] },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
       });
+      mockUseComponentTemplates.mockReturnValue({ data: componentTemplates });
 
       renderComponent();
 
@@ -472,12 +478,13 @@ describe('<UnitCard />', () => {
     it('hides AddComponentWidget when there are no component templates', async () => {
       mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
       mockUseUnitHandler.mockReturnValue({
-        data: { components: [], componentTemplates: [] },
+        data: { components: [] },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
       });
+      mockUseComponentTemplates.mockReturnValue({ data: [] });
 
       renderComponent();
 
@@ -496,17 +503,19 @@ describe('<UnitCard />', () => {
       mockUseUnitHandler.mockReturnValue({
         data: {
           components: [],
-          componentTemplates: [{
-            type: 'html',
-            displayName: 'Text',
-            templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
-            supportLegend: {},
-          }],
         },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
+      });
+      mockUseComponentTemplates.mockReturnValue({
+        data: [{
+          type: 'html',
+          displayName: 'Text',
+          templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+          supportLegend: {},
+        }],
       });
 
       renderComponent();
@@ -530,17 +539,19 @@ describe('<UnitCard />', () => {
       mockUseUnitHandler.mockReturnValue({
         data: {
           components: [],
-          componentTemplates: [{
-            type: 'html',
-            displayName: 'Text',
-            templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
-            supportLegend: {},
-          }],
         },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
+      });
+      mockUseComponentTemplates.mockReturnValue({
+        data: [{
+          type: 'html',
+          displayName: 'Text',
+          templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+          supportLegend: {},
+        }],
       });
 
       renderComponent();
@@ -567,17 +578,19 @@ describe('<UnitCard />', () => {
       mockUseUnitHandler.mockReturnValue({
         data: {
           components: [],
-          componentTemplates: [{
-            type: 'html',
-            displayName: 'Text',
-            templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
-            supportLegend: {},
-          }],
         },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
+      });
+      mockUseComponentTemplates.mockReturnValue({
+        data: [{
+          type: 'html',
+          displayName: 'Text',
+          templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+          supportLegend: {},
+        }],
       });
 
       renderComponent();
@@ -607,21 +620,23 @@ describe('<UnitCard />', () => {
       mockUseUnitHandler.mockReturnValue({
         data: {
           components: [],
-          componentTemplates: [{
-            type: 'openassessment',
-            displayName: 'Open Response',
-            templates: [{
-              displayName: 'Open Response Assessment',
-              category: 'openassessment',
-              boilerplateName: undefined,
-            }],
-            supportLegend: {},
-          }],
         },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
+      });
+      mockUseComponentTemplates.mockReturnValue({
+        data: [{
+          type: 'openassessment',
+          displayName: 'Open Response',
+          templates: [{
+            displayName: 'Open Response Assessment',
+            category: 'openassessment',
+            boilerplateName: undefined,
+          }],
+          supportLegend: {},
+        }],
       });
 
       renderComponent();
@@ -655,12 +670,13 @@ describe('<UnitCard />', () => {
       mockShowPasteXBlock.current = true;
       mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
       mockUseUnitHandler.mockReturnValue({
-        data: { components: [], componentTemplates },
+        data: { components: [] },
         isLoading: false,
         isError: false,
         error: null,
         refetch: jest.fn(),
       });
+      mockUseComponentTemplates.mockReturnValue({ data: componentTemplates });
 
       renderComponent();
 

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -7,10 +7,15 @@ import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import { XBlock } from '@src/data/types';
 import UnitCard from './UnitCard';
 import cardMessages from '../card-header/messages';
+import componentMessages from './messages';
 
 const mockUseAcceptLibraryBlockChanges = jest.fn();
 const mockUseIgnoreLibraryBlockChanges = jest.fn();
 const mockUseUnitHandler = jest.fn();
+const mockCreateXBlock = jest.fn();
+const mockPasteBlock = jest.fn();
+const mockCopyToClipboard = jest.fn();
+const mockShowPasteXBlock = { current: false };
 
 jest.mock('@src/course-unit/data/apiHooks', () => ({
   useAcceptLibraryBlockChanges: () => ({
@@ -23,7 +28,42 @@ jest.mock('@src/course-unit/data/apiHooks', () => ({
 
 jest.mock('./data/hooks', () => ({
   useUnitHandler: (...args: unknown[]) => mockUseUnitHandler(...args),
+  useCreateXBlockInUnit: () => ({
+    mutateAsync: mockCreateXBlock,
+    isPending: false,
+  }),
 }));
+
+// Mock pasteBlock API call used by handlePasteComponent
+jest.mock('@src/course-outline/data/api', () => ({
+  ...jest.requireActual('@src/course-outline/data/api'),
+  pasteBlock: (...args: unknown[]) => mockPasteBlock(...args),
+  setCourseItemOrderList: jest.fn(),
+}));
+
+// Mock useClipboard hook to control showPasteXBlock
+jest.mock('@src/generic/clipboard', () => ({
+  useClipboard: () => ({
+    copyToClipboard: mockCopyToClipboard,
+    showPasteXBlock: mockShowPasteXBlock.current,
+  }),
+}));
+
+// Mock fetchCourseSectionQuery thunk (returns a plain action object)
+jest.mock('@src/course-outline/data/thunk', () => ({
+  ...jest.requireActual('@src/course-outline/data/thunk'),
+  fetchCourseSectionQuery: jest.fn(() => ({ type: 'MOCK_FETCH_SECTION' })),
+}));
+
+// Mock EditorPage to avoid heavy editor dependencies
+jest.mock('@src/editors/EditorPage', () => function MockEditorPage() {
+  return <div data-testid="mock-editor-page" />;
+});
+
+// Mock ModalIframe to simplify legacy editor testing
+jest.mock('@src/generic/modal-iframe', () => function MockModalIframe({ title }: { title: string }) {
+  return <div data-testid="mock-modal-iframe">{title}</div>;
+});
 
 const section = {
   id: 'block-v1:UNIX+UX1+2025_T3+type@section+block@0',
@@ -109,13 +149,19 @@ const renderComponent = (props?: object) => render(
 );
 
 describe('<UnitCard />', () => {
+  let mockShowToast: jest.Mock;
+
   beforeEach(() => {
-    initializeMocks();
+    const mocks = initializeMocks();
+    mockShowToast = mocks.mockShowToast as jest.Mock;
     mockWaffleFlags({ enableUnitExpandedView: true });
     mockUseUnitHandler.mockReset();
     mockUseUnitHandler.mockReturnValue({
-      data: undefined, isLoading: false, isError: false, error: null,
+      data: undefined, isLoading: false, isError: false, error: null, refetch: jest.fn(),
     });
+    mockPasteBlock.mockReset();
+    mockCreateXBlock.mockReset();
+    mockShowPasteXBlock.current = false;
   });
 
   it('render UnitCard component correctly', async () => {
@@ -253,6 +299,7 @@ describe('<UnitCard />', () => {
       isLoading: false,
       isError: true,
       error: new Error(errorMessage),
+      refetch: jest.fn(),
     });
 
     renderComponent();
@@ -282,6 +329,7 @@ describe('<UnitCard />', () => {
         isLoading: false,
         isError: false,
         error: null,
+        refetch: jest.fn(),
       });
 
       renderComponent();
@@ -339,6 +387,322 @@ describe('<UnitCard />', () => {
 
       const prevented = !editButton.dispatchEvent(clickEvent);
       expect(prevented).toBe(false);
+    });
+  });
+
+  describe('preview button', () => {
+    it('shows Preview option in the kebab menu', async () => {
+      const { findByTestId } = renderComponent();
+      const element = await findByTestId('unit-card');
+      const menu = await within(element).findByTestId('unit-card-header__menu-button');
+      await act(async () => fireEvent.click(menu));
+
+      const previewButton = within(element).getByTestId('unit-card-header__menu-preview-button');
+      expect(previewButton).toBeInTheDocument();
+      expect(previewButton).toHaveTextContent(cardMessages.menuPreview.defaultMessage);
+    });
+
+    it('opens the correct LMS preview URL in a new tab', async () => {
+      const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      const { findByTestId } = renderComponent();
+      const element = await findByTestId('unit-card');
+      const menu = await within(element).findByTestId('unit-card-header__menu-button');
+      await act(async () => fireEvent.click(menu));
+
+      const previewButton = within(element).getByTestId('unit-card-header__menu-preview-button');
+      await act(async () => fireEvent.click(previewButton));
+
+      const expectedUrl = `${getConfig().LMS_BASE_URL}/courses/5/jump_to/${unit.id}?preview=1`;
+      expect(windowOpenSpy).toHaveBeenCalledWith(expectedUrl, '_blank');
+      windowOpenSpy.mockRestore();
+    });
+  });
+
+  describe('add component widget', () => {
+    const componentTemplates = [
+      {
+        type: 'html',
+        displayName: 'Text',
+        templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+        supportLegend: {},
+      },
+    ];
+
+    it('renders AddComponentWidget when enableOutlineComponentCreation flag is true', async () => {
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: { components: [], componentTemplates },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand the unit
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      expect(await screen.findByTestId('add-component-widget')).toBeInTheDocument();
+    });
+
+    it('hides AddComponentWidget when enableOutlineComponentCreation flag is false', async () => {
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: false });
+      mockUseUnitHandler.mockReturnValue({
+        data: { components: [], componentTemplates },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand the unit
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      // Wait for components area to render, then check widget is absent
+      await waitFor(() => {
+        expect(screen.queryByTestId('add-component-widget')).not.toBeInTheDocument();
+      });
+    });
+
+    it('hides AddComponentWidget when there are no component templates', async () => {
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: { components: [], componentTemplates: [] },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('add-component-widget')).not.toBeInTheDocument();
+      });
+    });
+
+    it('passes showPasteXBlock=true to AddComponentWidget when clipboard has content', async () => {
+      // Enable the clipboard paste indicator
+      mockShowPasteXBlock.current = true;
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: {
+          components: [],
+          componentTemplates: [{
+            type: 'html',
+            displayName: 'Text',
+            templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+            supportLegend: {},
+          }],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand the unit to show AddComponentWidget
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      // Open the add-component dropdown
+      const toggle = await screen.findByText(componentMessages.addComponentButton.defaultMessage);
+      await act(async () => fireEvent.click(toggle));
+
+      // Paste option should be visible when showPasteXBlock is true
+      expect(screen.getByTestId('add-component-item-paste')).toBeInTheDocument();
+    });
+
+    it('does not show paste option when clipboard is empty', async () => {
+      // Clipboard has no pasteable content
+      mockShowPasteXBlock.current = false;
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: {
+          components: [],
+          componentTemplates: [{
+            type: 'html',
+            displayName: 'Text',
+            templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+            supportLegend: {},
+          }],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand the unit
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      // Open the dropdown
+      const toggle = await screen.findByText(componentMessages.addComponentButton.defaultMessage);
+      await act(async () => fireEvent.click(toggle));
+
+      // Paste option should NOT be visible
+      expect(screen.queryByTestId('add-component-item-paste')).not.toBeInTheDocument();
+    });
+
+    it('opens MFE editor after creating an MFE-supported component (e.g. html)', async () => {
+      // Simulate createXBlock returning a locator for an html component
+      mockCreateXBlock.mockResolvedValueOnce({
+        locator: 'block-v1:test+type@html+block@new1',
+        courseKey: 'course-v1:test+T1+2025',
+      });
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: {
+          components: [],
+          componentTemplates: [{
+            type: 'html',
+            displayName: 'Text',
+            templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+            supportLegend: {},
+          }],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand unit
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      // Open dropdown and click the HTML component type
+      const toggle = await screen.findByText(componentMessages.addComponentButton.defaultMessage);
+      await act(async () => fireEvent.click(toggle));
+      await act(async () => fireEvent.click(screen.getByTestId('add-component-item-html')));
+
+      // The MFE editor modal should appear (mocked EditorPage inside .editor-page div)
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-editor-page')).toBeInTheDocument();
+      });
+    });
+
+    it('opens legacy editor after creating a non-MFE component (e.g. openassessment)', async () => {
+      // Simulate createXBlock returning a locator for an ORA component
+      mockCreateXBlock.mockResolvedValueOnce({
+        locator: 'block-v1:test+type@openassessment+block@new2',
+        courseKey: 'course-v1:test+T1+2025',
+      });
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: {
+          components: [],
+          componentTemplates: [{
+            type: 'openassessment',
+            displayName: 'Open Response',
+            templates: [{
+              displayName: 'Open Response Assessment',
+              category: 'openassessment',
+              boilerplateName: undefined,
+            }],
+            supportLegend: {},
+          }],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand unit
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      // Open dropdown and click the ORA component type
+      const toggle = await screen.findByText(componentMessages.addComponentButton.defaultMessage);
+      await act(async () => fireEvent.click(toggle));
+      await act(async () => fireEvent.click(screen.getByTestId('add-component-item-openassessment')));
+
+      // Legacy editor modal (iframe) should appear — MockModalIframe renders with a title
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-modal-iframe')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handlePasteComponent', () => {
+    const componentTemplates = [{
+      type: 'html',
+      displayName: 'Text',
+      templates: [{ displayName: 'Text', category: 'html', boilerplateName: undefined }],
+      supportLegend: {},
+    }];
+
+    // Helper to expand the unit and open the add-component dropdown with paste enabled
+    const setupPasteScenario = async () => {
+      mockShowPasteXBlock.current = true;
+      mockWaffleFlags({ enableUnitExpandedView: true, enableOutlineComponentCreation: true });
+      mockUseUnitHandler.mockReturnValue({
+        data: { components: [], componentTemplates },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      // Expand the unit
+      const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+      fireEvent.click(expandButton);
+
+      // Open the add-component dropdown
+      const toggle = await screen.findByText(componentMessages.addComponentButton.defaultMessage);
+      await act(async () => fireEvent.click(toggle));
+    };
+
+    it('calls pasteBlock and refreshes data on successful paste', async () => {
+      // pasteBlock resolves successfully
+      mockPasteBlock.mockResolvedValueOnce({ locator: 'block-v1:pasted' });
+
+      await setupPasteScenario();
+
+      // Click the paste option
+      const pasteItem = screen.getByTestId('add-component-item-paste');
+      await act(async () => fireEvent.click(pasteItem));
+
+      // pasteBlock should be called with the unit id
+      await waitFor(() => {
+        expect(mockPasteBlock).toHaveBeenCalledWith(unit.id);
+      });
+    });
+
+    it('shows an error toast when pasteBlock fails', async () => {
+      // pasteBlock rejects with an error
+      mockPasteBlock.mockRejectedValueOnce(new Error('Paste failed'));
+
+      await setupPasteScenario();
+
+      // Click the paste option
+      const pasteItem = screen.getByTestId('add-component-item-paste');
+      await act(async () => fireEvent.click(pasteItem));
+
+      // Error toast should be called with the addComponentError message
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(componentMessages.addComponentError.defaultMessage);
+      });
     });
   });
 });

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -42,7 +42,7 @@ import EditorPage from '@src/editors/EditorPage';
 import supportedEditors from '@src/editors/supportedEditors';
 import DraggableList, { SortableItem as GenericSortableItem } from '@src/generic/DraggableList';
 import { ToastContext } from '@src/generic/toast-context';
-import { useUnitHandler } from './data/hooks';
+import { useUnitHandler, useComponentTemplates } from './data/hooks';
 import AddComponentWidget from './AddComponentWidget';
 import type { CreatedXBlockInfo } from './AddComponentWidget';
 import messages from './messages';
@@ -136,6 +136,14 @@ const UnitCard = ({
     refetch: refetchUnitData,
   } = useUnitHandler(id, isExpanded && waffleFlags.enableUnitExpandedView);
 
+  // Fetch component templates separately via the existing container_handler API.
+  // Templates are course-level (same for every unit), so cached per courseId.
+  const { data: componentTemplates } = useComponentTemplates(
+    id,
+    courseId || '',
+    isExpanded && waffleFlags.enableUnitExpandedView && waffleFlags.enableOutlineComponentCreation,
+  );
+
   const blockSyncData = useMemo(() => {
     if (!upstreamInfo?.readyToSync) {
       return undefined;
@@ -210,7 +218,7 @@ const UnitCard = ({
     try {
       await pasteBlock(id);
       dispatch(fetchCourseSectionQuery([section.id]));
-      refetchUnitData();
+      await refetchUnitData();
     } catch {
       showToast(intl.formatMessage(messages.addComponentError));
     }
@@ -592,17 +600,17 @@ const UnitCard = ({
                 );
               })()}
               {waffleFlags.enableOutlineComponentCreation
-                && unitData?.componentTemplates
-                && unitData.componentTemplates.length > 0 && (
+                && componentTemplates
+                && componentTemplates.length > 0 && (
                 <div className="mt-3 mb-0" data-testid="add-component-widget">
                   <AddComponentWidget
                     unitId={id}
-                    componentTemplates={unitData.componentTemplates}
+                    componentTemplates={componentTemplates}
                     showPasteXBlock={!!showPasteXBlock}
                     onPasteComponent={handlePasteComponent}
-                    onComponentCreated={(info: CreatedXBlockInfo) => {
+                    onComponentCreated={async (info: CreatedXBlockInfo) => {
                       dispatch(fetchCourseSectionQuery([section.id]));
-                      refetchUnitData();
+                      await refetchUnitData();
                       const editorBlockType = info.category || info.type;
                       if (supportsMFEEditor(editorBlockType)) {
                         // MFE editor available (html, video, problem, games, etc.)

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -22,7 +22,7 @@ import { useWaffleFlags } from '@src/data/apiHooks';
 import CourseOutlineUnitCardExtraActionsSlot from '@src/plugin-slots/CourseOutlineUnitCardExtraActionsSlot';
 import { setCurrentItem, setCurrentSection, setCurrentSubsection } from '@src/course-outline/data/slice';
 import { fetchCourseSectionQuery } from '@src/course-outline/data/thunk';
-import { setCourseItemOrderList } from '@src/course-outline/data/api';
+import { setCourseItemOrderList, pasteBlock } from '@src/course-outline/data/api';
 import { RequestStatus, RequestStatusType } from '@src/data/constants';
 import CardHeader from '@src/course-outline/card-header/CardHeader';
 import SortableItem from '@src/course-outline/drag-helper/SortableItem';
@@ -43,6 +43,8 @@ import supportedEditors from '@src/editors/supportedEditors';
 import DraggableList, { SortableItem as GenericSortableItem } from '@src/generic/DraggableList';
 import { ToastContext } from '@src/generic/toast-context';
 import { useUnitHandler } from './data/hooks';
+import AddComponentWidget from './AddComponentWidget';
+import type { CreatedXBlockInfo } from './AddComponentWidget';
 import messages from './messages';
 
 interface UnitCardProps {
@@ -106,7 +108,7 @@ const UnitCard = ({
   const previousComponentsOrder = useRef<any[]>([]);
   const namePrefix = 'unit';
 
-  const { copyToClipboard } = useClipboard();
+  const { copyToClipboard, showPasteXBlock } = useClipboard();
   const { courseId } = useParams();
   const queryClient = useQueryClient();
   const { showToast } = useContext(ToastContext);
@@ -197,6 +199,22 @@ const UnitCard = ({
   const handleCopyClick = () => {
     copyToClipboard(id);
   };
+
+  const handlePreviewClick = useCallback(() => {
+    const lmsBaseUrl = getConfig().LMS_BASE_URL;
+    const previewUrl = `${lmsBaseUrl}/courses/${courseId}/jump_to/${id}?preview=1`;
+    window.open(previewUrl, '_blank');
+  }, [courseId, id]);
+
+  const handlePasteComponent = useCallback(async () => {
+    try {
+      await pasteBlock(id);
+      dispatch(fetchCourseSectionQuery([section.id]));
+      refetchUnitData();
+    } catch {
+      showToast(intl.formatMessage(messages.addComponentError));
+    }
+  }, [id, section.id, dispatch, refetchUnitData, showToast, intl]);
 
   const handleExpandContent = () => {
     setIsExpanded((prevState) => !prevState);
@@ -421,6 +439,7 @@ const UnitCard = ({
             hasChanges={hasChanges}
             cardId={id}
             onClickMenuButton={handleClickMenuButton}
+            onClickPreview={handlePreviewClick}
             onClickPublish={onOpenPublishModal}
             onClickConfigure={onOpenConfigureModal}
             onClickEdit={openForm}
@@ -572,6 +591,30 @@ const UnitCard = ({
                   </div>
                 );
               })()}
+              {waffleFlags.enableOutlineComponentCreation
+                && unitData?.componentTemplates
+                && unitData.componentTemplates.length > 0 && (
+                <div className="mt-3 mb-0" data-testid="add-component-widget">
+                  <AddComponentWidget
+                    unitId={id}
+                    componentTemplates={unitData.componentTemplates}
+                    showPasteXBlock={!!showPasteXBlock}
+                    onPasteComponent={handlePasteComponent}
+                    onComponentCreated={(info: CreatedXBlockInfo) => {
+                      dispatch(fetchCourseSectionQuery([section.id]));
+                      refetchUnitData();
+                      const editorBlockType = info.category || info.type;
+                      if (supportsMFEEditor(editorBlockType)) {
+                        // MFE editor available (html, video, problem, games, etc.)
+                        handleShowMFEEditor(editorBlockType, info.locator);
+                      } else {
+                        // No MFE editor — open the legacy Studio editor in an iframe
+                        handleShowLegacyEditModal(info.locator);
+                      }
+                    }}
+                  />
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/course-outline/unit-card/data/api.test.ts
+++ b/src/course-outline/unit-card/data/api.test.ts
@@ -1,0 +1,67 @@
+import { initializeMocks } from '@src/testUtils';
+import { getUnitHandler, getUnitHandlerApiUrl } from './api';
+
+// Mock unit handler API response in snake_case (as returned by Django)
+const mockUnitHandlerResponse = {
+  unit_id: 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123',
+  display_name: 'Test Unit',
+  components: [
+    { block_id: 'block-v1:edX+DemoX+Demo+type@html+block@1', block_type: 'html', display_name: 'Text' },
+    { block_id: 'block-v1:edX+DemoX+Demo+type@video+block@2', block_type: 'video', display_name: 'Video' },
+  ],
+  component_templates: [
+    {
+      type: 'html',
+      display_name: 'Text',
+      templates: [{ display_name: 'Text', category: 'html', boilerplate_name: null }],
+      support_legend: {},
+    },
+  ],
+};
+
+describe('unit-card data/api', () => {
+  let axiosMock: ReturnType<typeof initializeMocks>['axiosMock'];
+
+  beforeEach(() => {
+    ({ axiosMock } = initializeMocks());
+  });
+
+  describe('getUnitHandlerApiUrl', () => {
+    it('builds the correct URL for the given unitId', () => {
+      const unitId = 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123';
+      const url = getUnitHandlerApiUrl(unitId);
+      // URL should end with the unit handler path + unitId
+      expect(url).toContain(`/api/contentstore/v1/unit_handler/${unitId}`);
+    });
+  });
+
+  describe('getUnitHandler', () => {
+    const unitId = 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123';
+
+    it('fetches unit data and returns camelCase response', async () => {
+      // Mock the GET request for unit handler
+      axiosMock.onGet(getUnitHandlerApiUrl(unitId)).reply(200, mockUnitHandlerResponse);
+
+      const result = await getUnitHandler(unitId);
+
+      // Should have made exactly one GET request
+      expect(axiosMock.history.get).toHaveLength(1);
+      expect(axiosMock.history.get[0].url).toEqual(getUnitHandlerApiUrl(unitId));
+
+      // Response should be camelCased
+      expect(result.unitId).toBe(mockUnitHandlerResponse.unit_id);
+      expect(result.displayName).toBe(mockUnitHandlerResponse.display_name);
+      expect(result.components).toHaveLength(2);
+      expect(result.components[0].blockType).toBe('html');
+      expect(result.componentTemplates).toHaveLength(1);
+      expect(result.componentTemplates[0].displayName).toBe('Text');
+    });
+
+    it('throws on network error', async () => {
+      // Simulate a network failure
+      axiosMock.onGet(getUnitHandlerApiUrl(unitId)).networkError();
+
+      await expect(getUnitHandler(unitId)).rejects.toThrow();
+    });
+  });
+});

--- a/src/course-outline/unit-card/data/api.test.ts
+++ b/src/course-outline/unit-card/data/api.test.ts
@@ -9,14 +9,6 @@ const mockUnitHandlerResponse = {
     { block_id: 'block-v1:edX+DemoX+Demo+type@html+block@1', block_type: 'html', display_name: 'Text' },
     { block_id: 'block-v1:edX+DemoX+Demo+type@video+block@2', block_type: 'video', display_name: 'Video' },
   ],
-  component_templates: [
-    {
-      type: 'html',
-      display_name: 'Text',
-      templates: [{ display_name: 'Text', category: 'html', boilerplate_name: null }],
-      support_legend: {},
-    },
-  ],
 };
 
 describe('unit-card data/api', () => {
@@ -53,8 +45,6 @@ describe('unit-card data/api', () => {
       expect(result.displayName).toBe(mockUnitHandlerResponse.display_name);
       expect(result.components).toHaveLength(2);
       expect(result.components[0].blockType).toBe('html');
-      expect(result.componentTemplates).toHaveLength(1);
-      expect(result.componentTemplates[0].displayName).toBe('Text');
     });
 
     it('throws on network error', async () => {

--- a/src/course-outline/unit-card/data/api.ts
+++ b/src/course-outline/unit-card/data/api.ts
@@ -3,22 +3,43 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 const getStudioBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
+// Shape of a single component inside a unit
 export interface UnitComponent {
   blockId: string;
   blockType: string;
   displayName: string;
 }
 
+// Shape of one entry in the component_templates array returned by the API
+export interface ComponentTemplate {
+  type: string;
+  displayName: string;
+  beta?: boolean;
+  templates: Array<{
+    boilerplateName?: string;
+    category?: string;
+    displayName: string;
+    supportLevel?: string | boolean;
+  }>;
+  supportLegend: {
+    allowUnsupportedXblocks?: boolean;
+    documentationLabel?: string;
+    showLegend?: boolean;
+  };
+}
+
+// Full response from the unit_handler endpoint
 export interface UnitHandlerData {
   unitId: string;
   displayName: string;
   components: UnitComponent[];
+  componentTemplates: ComponentTemplate[];
 }
 
 export const getUnitHandlerApiUrl = (unitId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/unit_handler/${unitId}`;
 
 /**
- * Get unit handler data.
+ * Get unit handler data including components and available component templates.
  * @param {string} unitId
  * @returns {Promise<UnitHandlerData>}
  */

--- a/src/course-outline/unit-card/data/api.ts
+++ b/src/course-outline/unit-card/data/api.ts
@@ -33,17 +33,32 @@ export interface UnitHandlerData {
   unitId: string;
   displayName: string;
   components: UnitComponent[];
-  componentTemplates: ComponentTemplate[];
 }
 
 export const getUnitHandlerApiUrl = (unitId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/unit_handler/${unitId}`;
 
 /**
- * Get unit handler data including components and available component templates.
+ * Get unit handler data (components list).
  * @param {string} unitId
  * @returns {Promise<UnitHandlerData>}
  */
 export async function getUnitHandler(unitId: string): Promise<UnitHandlerData> {
   const { data } = await getAuthenticatedHttpClient().get(getUnitHandlerApiUrl(unitId));
   return camelCaseObject(data) as UnitHandlerData;
+}
+
+// Reuse the existing container_handler endpoint that already serves component_templates.
+const getContainerHandlerApiUrl = (unitId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/container_handler/${unitId}`;
+
+/**
+ * Fetch component templates for a unit by calling the existing container_handler API.
+ * Templates are course-level (identical for all units in a course), so callers
+ * should cache the result per courseId rather than per unit.
+ * @param {string} unitId – any unit in the course
+ * @returns {Promise<ComponentTemplate[]>}
+ */
+export async function getComponentTemplates(unitId: string): Promise<ComponentTemplate[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getContainerHandlerApiUrl(unitId));
+  const camelData = camelCaseObject(data);
+  return (camelData.componentTemplates ?? []) as ComponentTemplate[];
 }

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -1,13 +1,27 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { createCourseXblock } from '@src/course-unit/data/api';
-import { getUnitHandler } from './api';
+import { getUnitHandler, getComponentTemplates } from './api';
 
-// Hook to fetch unit data (components + templates) when expanded
+// Hook to fetch unit data (components list) when expanded
 export const useUnitHandler = (unitId: string, enabled: boolean = false) => useQuery({
   queryKey: ['unitHandler', unitId],
   queryFn: () => getUnitHandler(unitId),
   enabled: enabled && !!unitId,
+});
+
+// Hook to fetch component templates via the existing container_handler endpoint.
+// Templates are course-level (identical for every unit in a course), so we key
+// by courseId and use a long staleTime to avoid re-fetching on every unit expand.
+export const useComponentTemplates = (
+  unitId: string,
+  courseId: string,
+  enabled: boolean = false,
+) => useQuery({
+  queryKey: ['componentTemplates', courseId],
+  queryFn: () => getComponentTemplates(unitId),
+  enabled: enabled && !!unitId && !!courseId,
+  staleTime: 5 * 60 * 1000, // 5 minutes — templates rarely change within a session
 });
 
 // Hook to create a new xblock component inside a unit, reusing the course-unit API

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -1,8 +1,38 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { createCourseXblock } from '@src/course-unit/data/api';
 import { getUnitHandler } from './api';
 
+// Hook to fetch unit data (components + templates) when expanded
 export const useUnitHandler = (unitId: string, enabled: boolean = false) => useQuery({
   queryKey: ['unitHandler', unitId],
   queryFn: () => getUnitHandler(unitId),
   enabled: enabled && !!unitId,
 });
+
+// Hook to create a new xblock component inside a unit, reusing the course-unit API
+export const useCreateXBlockInUnit = (unitId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // Wrap createCourseXblock to normalize the response with camelCase keys
+    mutationFn: async (params: {
+      parentLocator: string;
+      type: string;
+      category?: string;
+      boilerplate?: string;
+    }) => {
+      const data = await createCourseXblock({
+        type: params.type,
+        category: params.category,
+        parentLocator: params.parentLocator,
+        boilerplate: params.boilerplate,
+      });
+      // Normalize snake_case response (locator, course_key) to camelCase
+      return camelCaseObject(data) as { locator: string; courseKey: string };
+    },
+    onSuccess: () => {
+      // Refetch the unit handler data so the new component appears
+      queryClient.invalidateQueries({ queryKey: ['unitHandler', unitId] });
+    },
+  });
+};

--- a/src/course-outline/unit-card/messages.js
+++ b/src/course-outline/unit-card/messages.js
@@ -51,7 +51,7 @@ const messages = defineMessages({
     defaultMessage: 'Paste component',
     description: 'Label for the paste component option in the add component dropdown',
   },
-  supportPartiallySuppported: {
+  supportPartiallySupported: {
     id: 'course-authoring.course-outline.unit.support-partially-supported',
     defaultMessage: 'Partially supported',
     description: 'Label shown next to advanced components that are partially supported',

--- a/src/course-outline/unit-card/messages.js
+++ b/src/course-outline/unit-card/messages.js
@@ -36,6 +36,46 @@ const messages = defineMessages({
     defaultMessage: 'Failed to save component',
     description: 'Error message shown when component save fails',
   },
+  addComponentButton: {
+    id: 'course-authoring.course-outline.unit.add-component-button',
+    defaultMessage: 'Add component',
+    description: 'Label for the button to add a new component to a unit from the outline',
+  },
+  addComponentError: {
+    id: 'course-authoring.course-outline.unit.add-component-error',
+    defaultMessage: 'Failed to add component. Please try again.',
+    description: 'Error message shown when adding a component from the outline fails',
+  },
+  pasteComponent: {
+    id: 'course-authoring.course-outline.unit.paste-component',
+    defaultMessage: 'Paste component',
+    description: 'Label for the paste component option in the add component dropdown',
+  },
+  supportPartiallySuppported: {
+    id: 'course-authoring.course-outline.unit.support-partially-supported',
+    defaultMessage: 'Partially supported',
+    description: 'Label shown next to advanced components that are partially supported',
+  },
+  supportNotSupported: {
+    id: 'course-authoring.course-outline.unit.support-not-supported',
+    defaultMessage: 'Not supported',
+    description: 'Label shown next to advanced components that are not supported',
+  },
+  templateModalTitle: {
+    id: 'course-authoring.course-outline.unit.template-modal-title',
+    defaultMessage: 'Add {componentTitle} component',
+    description: 'Title for the modal that lets the user pick a specific template when a component type has multiple sub-types',
+  },
+  templateModalCancel: {
+    id: 'course-authoring.course-outline.unit.template-modal-cancel',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button in the template selection modal',
+  },
+  templateModalSelect: {
+    id: 'course-authoring.course-outline.unit.template-modal-select',
+    defaultMessage: 'Select',
+    description: 'Submit button in the template selection modal',
+  },
 });
 
 export default messages;

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -34,6 +34,7 @@ export const waffleFlagDefaults = {
   enableCourseOptimizer: false,
   enableCourseOptimizerCheckPrevRunLinks: false,
   enableUnitExpandedView: false,
+  enableOutlineComponentCreation: false,
   useNewHomePage: true,
   useNewCustomPages: true,
   useNewScheduleDetailsPage: true,

--- a/src/generic/DraggableList/DraggableList.jsx
+++ b/src/generic/DraggableList/DraggableList.jsx
@@ -37,20 +37,22 @@ const DraggableList = ({
 
   const handleDragEnd = useCallback((event) => {
     const { active, over } = event;
-    if (active.id !== over.id) {
+    if (over && active.id !== over.id) {
       let updatedArray;
-      setState(() => {
-        const [activeElement] = itemList.filter(item => item.id === active.id);
-        const [overElement] = itemList.filter(item => item.id === over.id);
-        const oldIndex = itemList.indexOf(activeElement);
-        const newIndex = itemList.indexOf(overElement);
-        updatedArray = arrayMove(itemList, oldIndex, newIndex);
+      // Use the functional updater to access the latest state, avoiding stale closure
+      // on itemList when items are added/removed between renders.
+      setState((prevList) => {
+        const [activeElement] = prevList.filter(item => item.id === active.id);
+        const [overElement] = prevList.filter(item => item.id === over.id);
+        const oldIndex = prevList.indexOf(activeElement);
+        const newIndex = prevList.indexOf(overElement);
+        updatedArray = arrayMove(prevList, oldIndex, newIndex);
         return updatedArray;
       });
       updateOrder()(updatedArray);
     }
     setActiveId?.(null);
-  }, [updateOrder, setActiveId]);
+  }, [setState, updateOrder, setActiveId]);
 
   const handleDragStart = useCallback((event) => {
     setActiveId?.(event.active.id);


### PR DESCRIPTION
## Description

- Added AddComponentWidget to enable creating components directly from the unit outline.
- Integrated component templates from API and support for paste functionality.
- Added waffle flag `enableOutlineComponentCreation` to control feature rollout.
- Implemented preview option in unit card menu to open LMS preview.
- Added support for opening MFE or legacy editors after component creation.
- Included comprehensive tests and API updates for component templates.

This improves authoring workflow by allowing quick component creation and preview directly from the outline.

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-533