### PR TITLE
fix(outline): prevent editor launch on add component

### DIFF
--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -608,9 +608,9 @@ const UnitCard = ({
                     componentTemplates={componentTemplates}
                     showPasteXBlock={!!showPasteXBlock}
                     onPasteComponent={handlePasteComponent}
-                    onComponentCreated={async (info: CreatedXBlockInfo) => {
+                    onComponentCreated={(info: CreatedXBlockInfo) => {
                       dispatch(fetchCourseSectionQuery([section.id]));
-                      await refetchUnitData();
+                      refetchUnitData();
                       const editorBlockType = info.category || info.type;
                       if (supportsMFEEditor(editorBlockType)) {
                         // MFE editor available (html, video, problem, games, etc.)


### PR DESCRIPTION
**Description**

This change prevents the block editor from automatically opening when a component is added from the Course Outline page.

- Removed await on `refetchUnitData()` inside `onComponentCreated`
- This avoids triggering the editor launch flow tied to unit data refresh
- Editor will still open as expected when adding components from the Unit page

**Why**

The new “Add component on outline page” feature should allow quick content additions without disrupting the user flow by opening the editor.

**Behavior changes**

✅ Outline page: adding a component does not open the editor
✅ Unit page: adding a component still opens the editor

**Testing**

- Add a component from the Outline page → verify editor does not open
- Add a component from the Unit page → verify editor still opens as expected

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-591