### PR TITLE
feat: implemented transcript editor

### DIFF
--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -54,6 +54,7 @@ export const waffleFlagDefaults = {
   useReactMarkdownEditor: true,
   useVideoGalleryFlow: false,
   enableAudioDescription: false,
+  enableTranscriptEditor: false,
 } as const;
 
 export type WaffleFlagName = keyof typeof waffleFlagDefaults;

--- a/src/files-and-videos/generic/FileMenu.jsx
+++ b/src/files-and-videos/generic/FileMenu.jsx
@@ -59,7 +59,7 @@ const FileMenu = ({
           {intl.formatMessage(messages.downloadTitle)}
         </Dropdown.Item>
         <Dropdown.Item onClick={openAssetInfo}>
-          {intl.formatMessage(messages.infoTitle)}
+          {intl.formatMessage(fileType === 'video' ? messages.infoAndTranscriptsTitle : messages.infoTitle)}
         </Dropdown.Item>
         <Dropdown.Divider />
         <Dropdown.Item

--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -24,6 +24,7 @@ import {
   MoreInfoColumn,
   FilterStatus,
   Footer,
+  TranscriptColumn,
 } from './table-components';
 import ApiStatusToast from './ApiStatusToast';
 import DeleteConfirmationModal from './DeleteConfirmationModal';
@@ -42,6 +43,7 @@ const FileTable = ({
   maxFileSize,
   thumbnailPreview,
   infoModalSidebar,
+  infoModalContentUnderPreview,
 }) => {
   const intl = useIntl();
   const pageCount = Math.ceil(files.length / 50);
@@ -185,7 +187,13 @@ const FileTable = ({
 
   const hasMoreInfoColumn = tableColumns.filter(col => col.id === 'moreInfo').length === 1;
   if (!hasMoreInfoColumn) {
-    tableColumns.push({ ...moreInfoColumn });
+    tableColumns.push({ ...moreInfoColumn }); // eslint-disable-line no-param-reassign
+  }
+
+  const transcriptColIndex = tableColumns.findIndex(col => col.id === 'transcriptStatus');
+  if (transcriptColIndex !== -1) {
+    // eslint-disable-next-line no-param-reassign, react/prop-types
+    tableColumns[transcriptColIndex].Cell = ({ row }) => TranscriptColumn({ row, handleOpenFileInfo });
   }
 
   return (
@@ -293,6 +301,7 @@ const FileTable = ({
           usagePathStatus={usagePathStatus}
           error={usageErrorMessages}
           sidebar={infoModalSidebar}
+          contentUnderPreview={infoModalContentUnderPreview(selectedRows[0].original)}
         />
       )}
 
@@ -326,11 +335,13 @@ FileTable.propTypes = {
   maxFileSize: PropTypes.number.isRequired,
   thumbnailPreview: PropTypes.func.isRequired,
   infoModalSidebar: PropTypes.func.isRequired,
+  infoModalContentUnderPreview: PropTypes.func,
 };
 
 FileTable.defaultProps = {
   files: null,
   handleLockFile: () => {},
+  infoModalContentUnderPreview: () => null,
 };
 
 export default FileTable;

--- a/src/files-and-videos/generic/InfoModal.jsx
+++ b/src/files-and-videos/generic/InfoModal.jsx
@@ -24,6 +24,7 @@ const InfoModal = ({
   usagePathStatus,
   error,
   sidebar,
+  contentUnderPreview,
 }) => {
   const intl = useIntl();
   const [activeTab, setActiveTab] = useState('fileInfo');
@@ -75,6 +76,7 @@ const InfoModal = ({
                 thumbnailPreview={thumbnailPreview}
                 imageSize={{ width: '503px', height: '281px' }}
               />
+              {contentUnderPreview}
               <div>
                 <div className="row m-0 font-weight-bold">
                   <FormattedMessage {...messages.usageTitle} />
@@ -114,10 +116,12 @@ InfoModal.propTypes = {
   error: PropTypes.arrayOf(PropTypes.string).isRequired,
   thumbnailPreview: PropTypes.func.isRequired,
   sidebar: PropTypes.func.isRequired,
+  contentUnderPreview: PropTypes.node,
 };
 
 InfoModal.defaultProps = {
   file: null,
+  contentUnderPreview: null,
 };
 
 export default InfoModal;

--- a/src/files-and-videos/generic/messages.js
+++ b/src/files-and-videos/generic/messages.js
@@ -115,6 +115,11 @@ const messages = defineMessages({
     defaultMessage: 'Info',
     description: 'Label for info button in card menu dropdown',
   },
+  infoAndTranscriptsTitle: {
+    id: 'course-authoring.files-and-uploads.cardMenu.infoAndTranscriptsTitle',
+    defaultMessage: 'Info and transcripts',
+    description: 'Label for video info button in card menu dropdown',
+  },
   downloadEncodingsTitle: {
     id: 'course-authoring.files-and-uploads.cardMenu.downloadEncodingsTitle',
     defaultMessage: 'Download video list (.csv)',

--- a/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.jsx
@@ -109,7 +109,7 @@ const MoreInfoColumn = ({
             variant="tertiary"
             onClick={() => handleOpenFileInfo(row.original)}
           >
-            {intl.formatMessage(messages.infoTitle)}
+            {intl.formatMessage(fileType === 'video' ? messages.infoAndTranscriptsTitle : messages.infoTitle)}
           </MenuItem>
           <hr className="my-2" />
           <MenuItem

--- a/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Icon } from '@openedx/paragon';
+import { Button, Icon } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 import { TRANSCRIPT_FAILURE_STATUSES } from '../../../videos-page/data/constants';
 
-const TranscriptColumn = ({ row }) => {
+const TranscriptColumn = ({ row, handleOpenFileInfo }) => {
   const { transcripts, transcriptionStatus } = row.original;
   const numOfTranscripts = transcripts?.length;
   const transcriptMessage = numOfTranscripts > 0 ? `(${numOfTranscripts}) available` : null;
@@ -15,12 +15,22 @@ const TranscriptColumn = ({ row }) => {
       {TRANSCRIPT_FAILURE_STATUSES.includes(transcriptionStatus) && (
         <Icon src={Info} size="sm" className="mr-2 text-danger-500" />
       )}
-      <FormattedMessage
-        id="course-authoring.videos-page.table.transcriptColumn.message"
-        description="Message with the number of transcripts available"
-        defaultMessage="{message}"
-        values={{ message: transcriptMessage }}
-      />
+      {numOfTranscripts > 0 && handleOpenFileInfo ? (
+        <Button
+          variant="link"
+          size="inline"
+          onClick={(e) => { e.stopPropagation(); handleOpenFileInfo(row.original); }}
+        >
+          {transcriptMessage}
+        </Button>
+      ) : (
+        <FormattedMessage
+          id="course-authoring.videos-page.table.transcriptColumn.message"
+          description="Message with the number of transcripts available"
+          defaultMessage="{message}"
+          values={{ message: transcriptMessage }}
+        />
+      )}
     </div>
   );
 };
@@ -32,6 +42,11 @@ TranscriptColumn.propTypes = {
       transcriptionStatus: PropTypes.string.isRequired,
     }.isRequired,
   }.isRequired,
+  handleOpenFileInfo: PropTypes.func,
+};
+
+TranscriptColumn.defaultProps = {
+  handleOpenFileInfo: null,
 };
 
 export default TranscriptColumn;

--- a/src/files-and-videos/index.scss
+++ b/src/files-and-videos/index.scss
@@ -79,3 +79,13 @@
 .video-upload-warning-text {
   font-size: 18px;
 }
+
+.transcript-upload-button {
+  border-radius: 5px;
+  border: 2px solid;
+
+  &:focus::before,
+  &:focus-visible::before {
+    display: none !important;
+  }
+}

--- a/src/files-and-videos/videos-page/CourseVideosTable.tsx
+++ b/src/files-and-videos/videos-page/CourseVideosTable.tsx
@@ -25,6 +25,7 @@ import {
 } from '@src/files-and-videos/videos-page/data/thunks';
 import { getFormattedDuration, resampleFile } from '@src/files-and-videos/videos-page/data/utils';
 import VideoInfoModalSidebar from '@src/files-and-videos/videos-page/info-sidebar';
+import InfoTab from '@src/files-and-videos/videos-page/info-sidebar/InfoTab';
 import messages from '@src/files-and-videos/videos-page/messages';
 import TranscriptSettings from '@src/files-and-videos/videos-page/transcript-settings';
 import UploadModal from '@src/files-and-videos/videos-page/upload-modal';
@@ -151,15 +152,16 @@ export const CourseVideosTable = () => {
     handleAddThumbnail,
     videoImageSettings,
   });
-  const infoModalSidebar = (video, activeTab, setActiveTab) => (
-    <VideoInfoModalSidebar video={video} activeTab={activeTab} setActiveTab={setActiveTab} />
+  const infoModalSidebar = (video) => (
+    <VideoInfoModalSidebar video={video} />
   );
+  const infoModalContentUnderPreview = (video) => (<InfoTab video={video} />);
   const maxFileSize = videoUploadMaxFileSize * 1073741824;
   const transcriptColumn = {
     id: 'transcriptStatus',
     Header: 'Transcript',
     accessor: 'transcriptStatus',
-    Cell: ({ row }) => TranscriptColumn({ row }),
+    Cell: ({ row, handleOpenFileInfo }: any) => TranscriptColumn({ row, handleOpenFileInfo }),
     Filter: CheckboxFilter,
     filter: 'exactTextCase',
     filterChoices: [
@@ -269,6 +271,7 @@ export const CourseVideosTable = () => {
               maxFileSize,
               thumbnailPreview,
               infoModalSidebar,
+              infoModalContentUnderPreview,
               files: videos,
             }}
           />

--- a/src/files-and-videos/videos-page/VideosPage.test.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.jsx
@@ -501,10 +501,10 @@ describe('Videos page', () => {
             });
 
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
 
           await waitFor(() => {
-            expect(screen.getByText(messages.infoTitle.defaultMessage)).toBeVisible();
+            expect(screen.getByText(messages.usageTitle.defaultMessage)).toBeVisible();
           });
 
           const { usageStatus } = store.getState().videos;
@@ -520,15 +520,12 @@ describe('Videos page', () => {
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1/usage`).reply(201, { usageLocations: [] });
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
           await waitFor(() => {
             expect(screen.getByText(messages.usageNotInUseMessage.defaultMessage)).toBeVisible();
           });
 
-          const infoTab = screen.getAllByRole('tab')[0];
-          expect(infoTab).toBeVisible();
-
-          expect(infoTab).toHaveClass('active');
+          expect(screen.getByText(messages.usageTitle.defaultMessage)).toBeVisible();
         });
 
         it('should open video info modal and show transcript tab', async () => {
@@ -537,16 +534,12 @@ describe('Videos page', () => {
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1/usage`).reply(201, { usageLocations: [] });
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
           await waitFor(() => {
             expect(screen.getByText(messages.usageNotInUseMessage.defaultMessage)).toBeVisible();
           });
 
-          const transcriptTab = screen.getAllByRole('tab')[1];
-          fireEvent.click(transcriptTab);
-          expect(transcriptTab).toBeVisible();
-
-          expect(transcriptTab).toHaveClass('active');
+          expect(screen.getByText('Transcript (0)')).toBeVisible();
         });
 
         it('should show transcript error', async () => {
@@ -555,12 +548,11 @@ describe('Videos page', () => {
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID3/usage`).reply(201, { usageLocations: [] });
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
 
-          const transcriptTab = screen.getAllByRole('tab')[1];
-          fireEvent.click(transcriptTab);
-
-          expect(screen.getByText('Transcript (1)')).toBeVisible();
+          await waitFor(() => {
+            expect(screen.getByText('Transcript (1)')).toBeVisible();
+          });
         });
       });
 
@@ -711,7 +703,7 @@ describe('Videos page', () => {
 
         axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID3/usage`).reply(404);
         fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-        fireEvent.click(screen.getByText('Info'));
+        fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
         await executeThunk(getUsagePaths({
           courseId,
           video: { id: 'mOckID3', displayName: 'mOckID3' },

--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -79,6 +79,16 @@ export async function downloadTranscript({
   saveAs(file, filename);
 }
 
+export async function fetchTranscriptContent({
+  videoId,
+  language,
+  apiUrl,
+}) {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(`${getApiBaseUrl()}${apiUrl}?edx_video_id=${videoId}&language_code=${language}`);
+  return data;
+}
+
 export async function uploadTranscript({
   videoId,
   newLanguage,

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
@@ -1,14 +1,32 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, {
+  useEffect, useMemo, useState, useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
-import { Button, Stack } from '@openedx/paragon';
-import { Add } from '@openedx/paragon/icons';
+import {
+  Button,
+  Icon,
+  IconButton,
+  Spinner,
+  Stack,
+  Toast,
+} from '@openedx/paragon';
+import {
+  Add,
+  CheckCircle,
+  Delete,
+  Error as ErrorIcon,
+  FileUpload,
+  Article,
+} from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import ErrorAlert from '../../../editors/sharedComponents/ErrorAlerts/ErrorAlert';
 import { getLanguages, getSortedTranscripts } from '../data/utils';
 import Transcript from './transcript-item';
+import LanguageSelect from './transcript-item/LanguageSelect';
+import { FileInput, useFileInput } from '../../generic';
 import {
   deleteVideoTranscript,
   downloadVideoTranscript,
@@ -17,6 +35,7 @@ import {
 } from '../data/thunks';
 import { RequestStatus } from '../../../data/constants';
 import messages from './messages';
+import { isValidSrt } from '../transcript-editor/srtUtils';
 
 const TranscriptTab = ({
   video,
@@ -35,9 +54,44 @@ const TranscriptTab = ({
     transcriptDownloadHandlerUrl,
   } = videoTranscriptSettings;
   const { transcripts, id, displayName } = video;
-  const languages = getLanguages(transcriptAvailableLanguages);
+  const languages = useMemo(
+    () => getLanguages(transcriptAvailableLanguages),
+    [transcriptAvailableLanguages],
+  );
   let sortedTranscripts = getSortedTranscripts(languages, transcripts);
   const [previousSelection, setPreviousSelection] = useState(sortedTranscripts);
+  const [isAddingTranscript, setIsAddingTranscript] = useState(false);
+  const [newLanguage, setNewLanguage] = useState('');
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [pendingFileName, setPendingFileName] = useState('');
+  const [isSubmittingNewTranscript, setIsSubmittingNewTranscript] = useState(false);
+  const [isSubmittingReplace, setIsSubmittingReplace] = useState(false);
+  const [showAddTranscriptError, setShowAddTranscriptError] = useState(false);
+  const [showAddedToast, setShowAddedToast] = useState(false);
+  const [invalidSrtFile, setInvalidSrtFile] = useState(false);
+
+  const addTranscriptFileInput = useFileInput({
+    onAddFile: (files) => {
+      const [file] = files;
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        if (!isValidSrt(e.target.result)) {
+          setInvalidSrtFile(true);
+          setSelectedFile(null);
+        } else {
+          setInvalidSrtFile(false);
+          setSelectedFile(file);
+          setShowAddTranscriptError(false);
+        }
+      };
+      reader.readAsText(file);
+    },
+    setSelectedRows: () => {},
+    setAddOpen: () => {},
+  });
 
   useEffect(() => {
     dispatch(resetErrors({ errorType: 'transcript' }));
@@ -45,17 +99,53 @@ const TranscriptTab = ({
     setPreviousSelection(sortedTranscripts);
   }, [transcripts]);
 
-  const handleAddEmptyTranscript = () => {
-    setPreviousSelection(['', ...previousSelection]);
-    if (divRef?.current?.scrollTo) {
-      divRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+  useEffect(() => {
+    if (isAddingTranscript) {
+      const firstAvailableLanguage = Object.keys(languages).find((lang) => !previousSelection.includes(lang));
+      setNewLanguage(firstAvailableLanguage || '');
+      setSelectedFile(null);
     }
-  };
+  }, [isAddingTranscript]);
+
+  useEffect(() => {
+    if (!isAddingTranscript || !isSubmittingNewTranscript) {
+      return;
+    }
+
+    if (transcriptStatus === RequestStatus.SUCCESSFUL) {
+      setIsSubmittingNewTranscript(false);
+      setPendingFileName('');
+      setIsAddingTranscript(false);
+      setSelectedFile(null);
+      setShowAddTranscriptError(false);
+      setShowAddedToast(true);
+    }
+
+    if (transcriptStatus === RequestStatus.FAILED) {
+      setIsSubmittingNewTranscript(false);
+      setPendingFileName('');
+      setSelectedFile(null);
+      setShowAddTranscriptError(true);
+    }
+  }, [isAddingTranscript, isSubmittingNewTranscript, transcriptStatus]);
+
+  useEffect(() => {
+    if (!isSubmittingReplace) {
+      return;
+    }
+    if (transcriptStatus === RequestStatus.SUCCESSFUL) {
+      setIsSubmittingReplace(false);
+      setShowAddedToast(true);
+    }
+    if (transcriptStatus === RequestStatus.FAILED) {
+      setIsSubmittingReplace(false);
+    }
+  }, [isSubmittingReplace, transcriptStatus]);
 
   const handleTranscript = (data, actionType) => {
     const {
       language,
-      newLanguage,
+      newLanguage: transcriptNewLanguage,
       file,
     } = data;
     dispatch(resetErrors({ errorType: 'transcript' }));
@@ -83,11 +173,14 @@ const TranscriptTab = ({
         }));
         break;
       case 'upload':
+        if (!isEmpty(language)) {
+          setIsSubmittingReplace(true);
+        }
         dispatch(uploadVideoTranscript({
           language,
           videoId: id,
           apiUrl: transcriptUploadHandlerUrl,
-          newLanguage,
+          newLanguage: transcriptNewLanguage,
           file,
           transcripts,
         }));
@@ -97,12 +190,29 @@ const TranscriptTab = ({
     }
   };
 
+  const availableLanguages = Object.entries(languages)
+    .filter(([lang]) => !previousSelection.includes(lang));
+
+  const handleSubmitNewTranscript = () => {
+    if (!newLanguage || !selectedFile) {
+      return;
+    }
+    setShowAddTranscriptError(false);
+    setIsSubmittingNewTranscript(true);
+    setPendingFileName(selectedFile.name);
+    handleTranscript({
+      language: '',
+      newLanguage,
+      file: selectedFile,
+    }, 'upload');
+  };
+
   return (
     <Stack gap={3}>
       <div ref={divRef} style={{ overflowY: 'auto', maxHeight: '310px' }} className="px-1 py-2">
         <ErrorAlert
           hideHeading={false}
-          isError={transcriptStatus === RequestStatus.FAILED && !isEmpty(errors.transcript)}
+          isError={!isAddingTranscript && transcriptStatus === RequestStatus.FAILED && !isEmpty(errors.transcript)}
         >
           <ul className="p-0">
             {errors.transcript.map(message => (
@@ -112,28 +222,146 @@ const TranscriptTab = ({
             ))}
           </ul>
         </ErrorAlert>
-        {previousSelection.map(transcript => (
-          <Transcript
-            {...{
-              languages,
-              transcript,
-              previousSelection,
-              handleTranscript,
-            }}
-          />
-        ))}
+        {isAddingTranscript ? (
+          <Stack gap={3}>
+            <div className="h4 mb-0">{intl.formatMessage(messages.newTranscriptTitle)}</div>
+
+            <div>
+              <LanguageSelect
+                options={languages}
+                value={newLanguage}
+                placeholderText={intl.formatMessage(messages.languageSelectPlaceholder)}
+                previousSelection={previousSelection}
+                className="col-12 p-0"
+                handleSelect={(lang) => {
+                  setNewLanguage(lang);
+                  setShowAddTranscriptError(false);
+                }}
+              />
+            </div>
+
+            {!selectedFile && !isSubmittingNewTranscript && (
+              <Button
+                variant="outline-primary"
+                iconBefore={FileUpload}
+                className="justify-content-center w-100 mb-0 transcript-upload-button"
+                onClick={addTranscriptFileInput.click}
+              >
+                {intl.formatMessage(messages.uploadFileLabel)}
+              </Button>
+            )}
+
+            {isSubmittingNewTranscript ? (
+              <Stack direction="horizontal" className="align-items-center text-gray-700 py-1">
+                <Spinner animation="border" size="sm" className="mr-2" />
+                <span className="small">{pendingFileName}</span>
+              </Stack>
+            ) : null}
+
+            {selectedFile && !isSubmittingNewTranscript ? (
+              <Stack
+                direction="horizontal"
+                className="align-items-center justify-content-between rounded py-1 transcript-tab__file-row"
+              >
+                <Stack direction="horizontal" gap={2} className="align-items-center text-gray-700 overflow-hidden transcript-tab__file-name-wrap">
+                  <Icon src={Article} size="sm" className="flex-shrink-0" />
+                  <span className="text-truncate transcript-tab__file-name">{selectedFile.name}</span>
+                </Stack>
+                <IconButton
+                  src={Delete}
+                  iconAs={Icon}
+                  alt={intl.formatMessage(messages.removeSelectedFileLabel)}
+                  onClick={() => setSelectedFile(null)}
+                  className="flex-shrink-0"
+                />
+              </Stack>
+            ) : null}
+
+            {showAddTranscriptError && (
+              <Stack direction="horizontal" gap={2} className="align-items-center text-danger-500">
+                <Icon src={ErrorIcon} size="xs" />
+                <span>{intl.formatMessage(messages.addTranscriptFailedLabel)}</span>
+              </Stack>
+            )}
+
+            {invalidSrtFile && (
+              <Stack direction="horizontal" gap={2} className="align-items-center text-danger-500">
+                <Icon src={ErrorIcon} size="xs" />
+                <span>{intl.formatMessage(messages.invalidSrtFormat)}</span>
+              </Stack>
+            )}
+
+            {!selectedFile && (
+              <div className="small text-gray-500">{intl.formatMessage(messages.uploadHelpText)}</div>
+            )}
+
+            <Stack direction="horizontal" gap={3} className="justify-content-end">
+              <Button
+                variant="tertiary"
+                disabled={isSubmittingNewTranscript}
+                onClick={() => {
+                  setIsAddingTranscript(false);
+                  setSelectedFile(null);
+                  setPendingFileName('');
+                  setIsSubmittingNewTranscript(false);
+                  setShowAddTranscriptError(false);
+                  setInvalidSrtFile(false);
+                }}
+              >
+                {intl.formatMessage(messages.cancelButtonLabel)}
+              </Button>
+              <Button
+                disabled={!selectedFile || !newLanguage || isSubmittingNewTranscript}
+                onClick={handleSubmitNewTranscript}
+              >
+                {intl.formatMessage(messages.addTranscriptButtonLabel)}
+              </Button>
+            </Stack>
+
+            <FileInput
+              key="new-transcript-input"
+              fileInput={addTranscriptFileInput}
+              supportedFileFormats={['.srt']}
+              allowMultiple={false}
+            />
+          </Stack>
+        ) : (
+          <>
+            {previousSelection.map(transcript => (
+              <Transcript
+                {...{
+                  languages,
+                  transcript,
+                  previousSelection,
+                  handleTranscript,
+                  video,
+                  transcriptSettings: videoTranscriptSettings,
+                }}
+              />
+            ))}
+          </>
+        )}
       </div>
+      {!isAddingTranscript && (
       <div className="border-top border-light-400">
         <Button
           variant="link"
           iconBefore={Add}
           size="sm"
           className="text-primary-500 justify-content-start pl-0 pt-3"
-          onClick={handleAddEmptyTranscript}
+          onClick={() => setIsAddingTranscript(true)}
+          disabled={availableLanguages.length === 0}
         >
           {intl.formatMessage(messages.uploadButtonLabel)}
         </Button>
       </div>
+      )}
+      <Toast show={showAddedToast} onClose={() => setShowAddedToast(false)}>
+        <Stack direction="horizontal" gap={2} className="align-items-center">
+          <Icon src={CheckCircle} className="text-success" />
+          <span>{intl.formatMessage(messages.newTranscriptAddedLabel)}</span>
+        </Stack>
+      </Toast>
     </Stack>
   );
 };

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
@@ -209,7 +209,7 @@ const TranscriptTab = ({
 
   return (
     <Stack gap={3}>
-      <div ref={divRef} style={{ overflowY: 'auto', maxHeight: '310px' }} className="px-1 py-2">
+      <div ref={divRef} style={{ overflowY: 'auto' }} className="px-1 py-2">
         <ErrorAlert
           hideHeading={false}
           isError={!isAddingTranscript && transcriptStatus === RequestStatus.FAILED && !isEmpty(errors.transcript)}

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.test.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.test.jsx
@@ -5,6 +5,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import ReactDOM from 'react-dom';
 
@@ -27,7 +28,6 @@ import {
 
 import { getApiBaseUrl } from '../data/api';
 import messages from './messages';
-import genericMessages from '../../generic/messages';
 import transcriptRowMessages from './transcript-item/messages';
 import VideosPageProvider from '../VideosPageProvider';
 import { deleteVideoTranscript } from '../data/thunks';
@@ -51,18 +51,34 @@ const defaultProps = {
 
 let axiosMock;
 let store;
+let queryClient;
 jest.mock('file-saver');
 
 const renderComponent = (props) => {
   render(
-    <IntlProvider locale="en">
-      <AppProvider store={store}>
-        <VideosPageProvider courseId={courseId}>
-          <TranscriptTab video={props} />
-        </VideosPageProvider>
-      </AppProvider>
-    </IntlProvider>,
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <VideosPageProvider courseId={courseId}>
+            <TranscriptTab video={props} />
+          </VideosPageProvider>
+        </AppProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
   );
+};
+
+const openAddForm = async () => {
+  const addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
+  await act(async () => { fireEvent.click(addButton); });
+};
+
+const selectLanguage = async (languageText, dropdownEl = null) => {
+  const dropdown = dropdownEl || screen.getByTestId('language-select-dropdown');
+  await act(async () => { fireEvent.click(dropdown); });
+  const allMatches = screen.getAllByText(languageText);
+  const option = allMatches.find(el => el.closest('.pgn__menu')) || allMatches[allMatches.length - 1];
+  await act(async () => { fireEvent.click(option); });
 };
 
 describe('TranscriptTab', () => {
@@ -77,89 +93,86 @@ describe('TranscriptTab', () => {
     });
     store = initializeStore(initialState);
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    axiosMock.onGet(/course_waffle_flags/).reply(200, {});
   });
 
   describe('with no transcripts preloaded', () => {
     it('should have add transcript button', async () => {
       renderComponent(defaultProps);
       const addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
-      const transcriptRow = screen.queryByTestId('transcript', { exact: false });
+      const transcriptRow = screen.queryByTestId('transcript-', { exact: false });
       expect(addButton).toBeInTheDocument();
       expect(transcriptRow).toBeNull();
     });
 
-    it('should delete empty transcript row', async () => {
+    it('should open and cancel new transcript form', async () => {
       renderComponent(defaultProps);
-      const addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
-      await act(async () => { fireEvent.click(addButton); });
+      await openAddForm();
 
-      const deleteButton = screen.getByLabelText('delete empty transcript');
-      await act(async () => { fireEvent.click(deleteButton); });
+      expect(screen.getByText(messages.newTranscriptTitle.defaultMessage)).toBeVisible();
 
-      expect(screen.getByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeVisible();
+      const cancelButton = screen.getByText(messages.cancelButtonLabel.defaultMessage);
+      await act(async () => { fireEvent.click(cancelButton); });
 
-      const confirmButton = screen.getByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage);
-      await act(async () => { fireEvent.click(confirmButton); });
-
-      expect(screen.queryByTestId('transcript-')).toBeNull();
+      expect(screen.queryByText(messages.newTranscriptTitle.defaultMessage)).toBeNull();
     });
 
     describe('uploadVideoTranscript as add function', () => {
-      let addButton;
-      const file = new File(['(⌐□_□)'], 'download.srt', { type: 'text/srt' });
-      beforeEach(async () => {
-        renderComponent(defaultProps);
-        addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
-
-        await act(async () => { fireEvent.click(addButton); });
-      });
+      const srtContent = '1\n00:00:00,000 --> 00:00:01,000\nTest\n';
+      const file = new File([srtContent], 'download.srt', { type: 'text/srt' });
 
       it('should upload new transcript', async () => {
         const user = userEvent.setup();
+        renderComponent(defaultProps);
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(204);
+
+        await openAddForm();
+        await selectLanguage('Arabic');
+
         await act(async () => {
-          const addFileInput = screen.getByLabelText(genericMessages.fileInputAriaLabel.defaultMessage);
-          expect(addFileInput).toBeInTheDocument();
-
-          await user.upload(addFileInput, file);
+          fireEvent.click(screen.getByText(messages.uploadFileLabel.defaultMessage));
         });
-        const addStatus = store.getState().videos.transcriptStatus;
+        const fileInputs = document.querySelectorAll('input[type="file"]');
+        await act(async () => {
+          await user.upload(fileInputs[fileInputs.length - 1], file);
+        });
 
+        const submitButton = screen.getByText(messages.addTranscriptButtonLabel.defaultMessage);
+        await act(async () => { fireEvent.click(submitButton); });
+
+        const addStatus = store.getState().videos.transcriptStatus;
         expect(addStatus).toEqual(RequestStatus.SUCCESSFUL);
       });
 
-      it('should show default error message', async () => {
+      it('should show default error message on upload failure', async () => {
         const user = userEvent.setup();
+        renderComponent(defaultProps);
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(404);
+
+        await openAddForm();
+        await selectLanguage('Arabic');
+
         await act(async () => {
-          const addFileInput = screen.getByLabelText(genericMessages.fileInputAriaLabel.defaultMessage);
-          await user.upload(addFileInput, file);
+          fireEvent.click(screen.getByText(messages.uploadFileLabel.defaultMessage));
         });
-        const addStatus = store.getState().videos.transcriptStatus;
-
-        expect(addStatus).toEqual(RequestStatus.FAILED);
-
-        expect(screen.getAllByText('Failed to add .')[0]).toBeVisible();
-      });
-
-      it('should show api provided error message', async () => {
-        const user = userEvent.setup();
-        axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(404, { error: 'api error' });
+        const fileInputs = document.querySelectorAll('input[type="file"]');
         await act(async () => {
-          const addFileInput = screen.getByLabelText(genericMessages.fileInputAriaLabel.defaultMessage);
-          await user.upload(addFileInput, file);
+          await user.upload(fileInputs[fileInputs.length - 1], file);
         });
+
+        const submitButton = screen.getByText(messages.addTranscriptButtonLabel.defaultMessage);
+        await act(async () => { fireEvent.click(submitButton); });
+
         const addStatus = store.getState().videos.transcriptStatus;
-
         expect(addStatus).toEqual(RequestStatus.FAILED);
-
-        expect(screen.getAllByText('api error')[0]).toBeVisible();
       });
     });
   });
 
-  describe('with one transcripts preloaded', () => {
+  describe('with one transcript preloaded', () => {
     const updatedProps = { ...defaultProps, transcripts: ['ar'] };
+
     beforeEach(() => {
       renderComponent(updatedProps);
     });
@@ -174,9 +187,7 @@ describe('TranscriptTab', () => {
     describe('deleteVideoTranscript', () => {
       beforeEach(async () => {
         const menuButton = screen.getByTestId('ar-transcript-menu');
-        await waitFor(() => {
-          fireEvent.click(menuButton);
-        });
+        await waitFor(() => { fireEvent.click(menuButton); });
 
         const deleteButton = screen.getByText(transcriptRowMessages.deleteTranscript.defaultMessage).closest('button');
         fireEvent.click(deleteButton);
@@ -184,15 +195,13 @@ describe('TranscriptTab', () => {
 
       it('should open delete confirmation modal and cancel delete', async () => {
         const cancelButton = screen.getByText(transcriptRowMessages.cancelDeleteLabel.defaultMessage);
-        await waitFor(() => {
-          fireEvent.click(cancelButton);
-        });
-
+        await waitFor(() => { fireEvent.click(cancelButton); });
         expect(screen.queryByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeNull();
       });
 
       it('should open delete confirmation modal and handle delete', async () => {
-        const confirmButton = screen.getByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage);
+        const confirmButton = screen.getAllByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage)
+          .find(el => el.closest('.btn-danger') || el.classList.contains('btn-danger'));
         axiosMock.onDelete(`${getApiBaseUrl()}/transcript_delete/${courseId}/mOckID0/ar`).reply(204);
         await act(async () => {
           fireEvent.click(confirmButton);
@@ -204,14 +213,13 @@ describe('TranscriptTab', () => {
           }), store.dispatch);
         });
         const deleteStatus = store.getState().videos.transcriptStatus;
-
         expect(deleteStatus).toEqual(RequestStatus.SUCCESSFUL);
-
         expect(screen.queryByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeNull();
       });
 
-      it('should show error message', async () => {
-        const confirmButton = screen.getByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage);
+      it('should show error message on delete failure', async () => {
+        const confirmButton = screen.getAllByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage)
+          .find(el => el.closest('.btn-danger') || el.classList.contains('btn-danger'));
         axiosMock.onDelete(`${getApiBaseUrl()}/transcript_delete/${courseId}/mOckID0/ar`).reply(404);
         await act(async () => {
           fireEvent.click(confirmButton);
@@ -223,11 +231,8 @@ describe('TranscriptTab', () => {
           }), store.dispatch);
         });
         const deleteStatus = store.getState().videos.transcriptStatus;
-
         expect(deleteStatus).toEqual(RequestStatus.FAILED);
-
         expect(screen.queryByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeNull();
-
         expect(screen.getAllByText('Failed to delete ar transcript.')[0]).toBeVisible();
       });
     });
@@ -236,9 +241,7 @@ describe('TranscriptTab', () => {
       let downloadButton;
       beforeEach(async () => {
         const menuButton = screen.getByTestId('ar-transcript-menu');
-        await waitFor(() => {
-          fireEvent.click(menuButton);
-        });
+        await waitFor(() => { fireEvent.click(menuButton); });
         downloadButton = screen.getByText(
           transcriptRowMessages.downloadTranscript.defaultMessage,
         ).closest('button');
@@ -248,26 +251,19 @@ describe('TranscriptTab', () => {
         axiosMock.onGet(
           `${getApiBaseUrl()}/transcript_download/?edx_video_id=${updatedProps.id}&language_code=ar`,
         ).reply(200, 'string of transcript');
-        await act(async () => {
-          fireEvent.click(downloadButton);
-        });
+        await act(async () => { fireEvent.click(downloadButton); });
         const downloadStatus = store.getState().videos.transcriptStatus;
-
         expect(downloadStatus).toEqual(RequestStatus.SUCCESSFUL);
       });
 
-      it('should show error message', async () => {
+      it('should show error message on download failure', async () => {
         const filename = 'mOckID0.mp4-ar.srt';
         axiosMock.onGet(
           `${getApiBaseUrl()}/transcript_download/?edx_video_id=${updatedProps.id}&language_code=ar`,
         ).reply(404);
-        await act(async () => {
-          fireEvent.click(downloadButton);
-        });
+        await act(async () => { fireEvent.click(downloadButton); });
         const downloadStatus = store.getState().videos.transcriptStatus;
-
         expect(downloadStatus).toEqual(RequestStatus.FAILED);
-
         expect(screen.getAllByText(`Failed to download ${filename}.`)[0]).toBeVisible();
       });
     });
@@ -275,24 +271,18 @@ describe('TranscriptTab', () => {
 
   describe('with multiple transcripts preloaded', () => {
     describe('uploadVideoTranscript as replace function', () => {
-      const file = new File(['(⌐□_□)'], 'download.srt', { type: 'text/srt' });
+      const srtContent = '1\n00:00:00,000 --> 00:00:01,000\nTest\n';
+      const file = new File([srtContent], 'download.srt', { type: 'text/srt' });
+
       beforeEach(async () => {
         const updatedProps = { ...defaultProps, transcripts: ['fr', 'ar'] };
         renderComponent(updatedProps);
-        const dropdownButton = screen.getAllByTestId('language-select-dropdown')[0];
-        await waitFor(() => {
-          fireEvent.click(dropdownButton);
-        });
 
-        const englishOption = screen.getByText('English');
-        await act(async () => {
-          fireEvent.click(englishOption);
-        });
+        const dropdownButtons = screen.getAllByTestId('language-select-dropdown');
+        await selectLanguage('English', dropdownButtons[0]);
 
         const menuButton = screen.getByTestId('ar-transcript-menu');
-        await waitFor(() => {
-          fireEvent.click(menuButton);
-        });
+        await waitFor(() => { fireEvent.click(menuButton); });
         const replaceButton = screen.getByText(
           transcriptRowMessages.replaceTranscript.defaultMessage,
         ).closest('button');
@@ -304,31 +294,28 @@ describe('TranscriptTab', () => {
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(204);
 
         await act(async () => {
-          const addFileInput = screen.getAllByLabelText(genericMessages.fileInputAriaLabel.defaultMessage)[0];
-          await user.upload(addFileInput, file);
+          const fileInputs = document.querySelectorAll('input[type="file"]');
+          await user.upload(fileInputs[0], file);
         });
-        const addStatus = store.getState().videos.transcriptStatus;
 
+        const addStatus = store.getState().videos.transcriptStatus;
         expect(addStatus).toEqual(RequestStatus.SUCCESSFUL);
 
         const updatedTranscripts = store.getState().models.videos[defaultProps.id].transcripts;
-
         expect(updatedTranscripts).toEqual(['fr', 'en']);
       });
 
-      it('should show error message', async () => {
+      it('should show error message on replace failure', async () => {
         const user = userEvent.setup();
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(404);
 
         await act(async () => {
-          const addFileInput = screen.getAllByLabelText(genericMessages.fileInputAriaLabel.defaultMessage)[0];
-          await user.upload(addFileInput, file);
+          const fileInputs = document.querySelectorAll('input[type="file"]');
+          await user.upload(fileInputs[0], file);
         });
 
         const addStatus = store.getState().videos.transcriptStatus;
-
         expect(addStatus).toEqual(RequestStatus.FAILED);
-
         expect(screen.getAllByText('Failed to replace ar with en.')[0]).toBeVisible();
       });
     });

--- a/src/files-and-videos/videos-page/info-sidebar/VideoInfoModalSidebar.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/VideoInfoModalSidebar.jsx
@@ -1,46 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Tabs,
-  Tab,
-} from '@openedx/paragon';
-import InfoTab from './InfoTab';
+import { Stack } from '@openedx/paragon';
 import TranscriptTab from './TranscriptTab';
 import messages from './messages';
-import { TRANSCRIPT_FAILURE_STATUSES } from '../data/constants';
 
 const VideoInfoModalSidebar = ({
   video,
-  activeTab,
-  setActiveTab,
 }) => {
   const intl = useIntl();
 
   return (
-    <Tabs
-      id="controlled-info-sidebar-tab"
-      activeKey={activeTab}
-      onSelect={(tab) => setActiveTab(tab)}
-    >
-      <Tab eventKey="fileInfo" title={intl.formatMessage(messages.infoTabTitle)}>
-        <InfoTab {...{ video }} />
-      </Tab>
-      <Tab
-        eventKey="fileTranscripts"
-        title={intl.formatMessage(
-          messages.transcriptTabTitle,
-          { transcriptCount: video.transcripts.length },
-        )}
-        notification={TRANSCRIPT_FAILURE_STATUSES.includes(video.transcriptionStatus) && (
-        <span>
-          <span className="sr-only">{intl.formatMessage(messages.notificationScreenReaderText)}</span>
-        </span>
-        )}
-      >
-        <TranscriptTab {...{ video }} />
-      </Tab>
-    </Tabs>
+    <Stack gap={2}>
+      <div className="font-weight-bold pb-2 border-bottom border-light-400">
+        {intl.formatMessage(messages.transcriptTabTitle, { transcriptCount: video.transcripts.length })}
+      </div>
+      <TranscriptTab {...{ video }} />
+    </Stack>
   );
 };
 
@@ -54,8 +30,6 @@ VideoInfoModalSidebar.propTypes = {
     transcripts: PropTypes.arrayOf(PropTypes.string),
     transcriptionStatus: PropTypes.string.isRequired,
   }),
-  activeTab: PropTypes.string.isRequired,
-  setActiveTab: PropTypes.func.isRequired,
 };
 
 VideoInfoModalSidebar.defaultProps = {

--- a/src/files-and-videos/videos-page/info-sidebar/messages.js
+++ b/src/files-and-videos/videos-page/info-sidebar/messages.js
@@ -40,6 +40,56 @@ const messages = defineMessages({
     defaultMessage: 'Add a transcript',
     description: 'Label for upload button',
   },
+  newTranscriptTitle: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.newTranscript.title',
+    defaultMessage: 'New transcript',
+    description: 'Heading shown when adding a new transcript',
+  },
+  uploadFileLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.uploadFile.label',
+    defaultMessage: 'Upload file',
+    description: 'Label for selecting a transcript file',
+  },
+  uploadHelpText: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.uploadFile.helpText',
+    defaultMessage: 'SRT file, max 25MB',
+    description: 'Help text shown under transcript upload button',
+  },
+  languageSelectPlaceholder: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.languageSelectPlaceholder',
+    defaultMessage: 'Select language',
+    description: 'Placeholder for language selector in new transcript form',
+  },
+  cancelButtonLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.cancel.label',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button text in new transcript form',
+  },
+  addTranscriptButtonLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.addTranscript.label',
+    defaultMessage: 'Add transcript',
+    description: 'Submit button label in new transcript form',
+  },
+  removeSelectedFileLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.removeSelectedFile.label',
+    defaultMessage: 'Remove selected file',
+    description: 'Accessible label for removing selected transcript file',
+  },
+  addTranscriptFailedLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.addTranscript.failed',
+    defaultMessage: 'Upload failed, please try again',
+    description: 'Inline error shown when adding transcript fails',
+  },
+  invalidSrtFormat: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.invalidSrtFormat',
+    defaultMessage: 'Invalid SRT format. Please upload a valid .srt file.',
+    description: 'Error shown when uploaded transcript file has invalid SRT content',
+  },
+  newTranscriptAddedLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.addTranscript.success',
+    defaultMessage: 'New transcript added',
+    description: 'Toast message shown when adding transcript succeeds',
+  },
 });
 
 export default messages;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
@@ -3,13 +3,19 @@ import PropTypes from 'prop-types';
 
 import {
   Button,
+  Form,
   Icon,
   ModalPopup,
   Menu,
   MenuItem,
   useToggle,
 } from '@openedx/paragon';
-import { Check, ExpandMore, ExpandLess } from '@openedx/paragon/icons';
+import {
+  Check,
+  ExpandMore,
+  ExpandLess,
+  Search,
+} from '@openedx/paragon/icons';
 import { isEmpty } from 'lodash';
 
 const LanguageSelect = ({
@@ -18,41 +24,67 @@ const LanguageSelect = ({
   options,
   handleSelect,
   placeholderText,
+  className = 'col-9 p-0',
 }) => {
   const currentSelection = isEmpty(value) ? placeholderText : options[value];
 
   const [isOpen, , close, toggle] = useToggle();
   const [target, setTarget] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredOptions = Object.entries(options).filter(([, text]) => (
+    text?.toLowerCase().includes(normalizedQuery)
+  ));
+
+  const handleClose = () => {
+    setSearchQuery('');
+    close();
+  };
 
   return (
     <>
-      <div className="col-9 p-0">
+      <div className={className}>
         <Button
           variant="tertiary"
           size="sm"
-          className="border border-gray-700 justify-content-between"
+          className="border border-gray-700 justify-content-between language-select-dropdown-btn"
           style={{ minWidth: '100%' }}
           id={`language-select-dropdown-${currentSelection}`}
           data-testid="language-select-dropdown"
-          iconAfter={isOpen ? ExpandLess : ExpandMore}
           onClick={toggle}
           ref={setTarget}
         >
-          {currentSelection}
+          <span className="language-select-dropdown-btn__text">{currentSelection}</span>
+          <span className="language-select-dropdown-btn__divider" />
+          <Icon src={isOpen ? ExpandLess : ExpandMore} />
         </Button>
       </div>
       <ModalPopup
         placement="bottom-end"
         positionRef={target}
         isOpen={isOpen}
-        onClose={close}
-        onEscapeKey={close}
+        onClose={handleClose}
+        onEscapeKey={handleClose}
       >
         <Menu
           className="language-select"
         >
           <div>
-            {Object.entries(options).map(([valueKey, text]) => {
+            <div className="px-2 pb-2 pt-1">
+              <Form.Control
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search languages"
+                controlClassName="w-100"
+                floatingLabel={null}
+              />
+            </div>
+            {filteredOptions.length === 0 && (
+              <div className="px-3 py-2 small text-muted">No results</div>
+            )}
+            {filteredOptions.map(([valueKey, text]) => {
               if (valueKey === value) {
                 return (
                   <MenuItem
@@ -74,7 +106,7 @@ const LanguageSelect = ({
                     size="sm"
                     onClick={() => {
                       handleSelect(valueKey);
-                      close();
+                      handleClose();
                     }}
                     key={`${valueKey}-item`}
                   >
@@ -97,7 +129,7 @@ const LanguageSelect = ({
           </div>
         </Menu>
         <div className="row justify-content-center">
-          <Icon src={ExpandMore} size="xs" />
+          <Icon src={Search} size="xs" />
         </div>
       </ModalPopup>
     </>
@@ -110,6 +142,7 @@ LanguageSelect.propTypes = {
   handleSelect: PropTypes.func.isRequired,
   placeholderText: PropTypes.string.isRequired,
   previousSelection: PropTypes.arrayOf(PropTypes.string).isRequired,
+  className: PropTypes.string,
 };
 
 export default LanguageSelect;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.scss
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.scss
@@ -1,3 +1,22 @@
+.language-select-dropdown-btn {
+  border-radius: 6px !important;
+  border-color: var(--pgn-color-gray-500) !important;
+
+  &__text {
+    flex: 1;
+    text-align: left;
+  }
+
+  &__divider {
+    display: inline-block;
+    width: 1px;
+    height: 1rem;
+    background-color: var(--pgn-color-gray-500);
+    margin: 0 0.5rem;
+    align-self: center;
+  }
+}
+
 .language-select {
   padding: 8px 0;
   margin: 0;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
@@ -1,30 +1,39 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Card,
+  ActionRow,
+  AlertModal,
   Button,
   Icon,
   IconButton,
+  Stack,
   useToggle,
 } from '@openedx/paragon';
-import { DeleteOutline } from '@openedx/paragon/icons';
+import { DeleteOutline, Error as ErrorIcon } from '@openedx/paragon/icons';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
 import { isEmpty } from 'lodash';
 import LanguageSelect from './LanguageSelect';
 import TranscriptMenu from './TranscriptMenu';
 import messages from './messages';
+import sidebarMessages from '../messages';
 import { FileInput, useFileInput } from '../../../generic';
+import TranscriptEditor from '../../transcript-editor';
+import { isValidSrt } from '../../transcript-editor/srtUtils';
 
 const Transcript = ({
   languages,
   transcript,
   previousSelection,
   handleTranscript,
+  video,
+  transcriptSettings,
   // injected
   intl,
 }) => {
   const [isConfirmationOpen, openConfirmation, closeConfirmation] = useToggle();
   const [newLanguage, setNewLanguage] = useState(transcript);
+  const [editorLanguage, setEditorLanguage] = useState('');
+  const [invalidSrtFile, setInvalidSrtFile] = useState(false);
   const language = transcript;
 
   useEffect(() => {
@@ -34,11 +43,23 @@ const Transcript = ({
   const input = useFileInput({
     onAddFile: (files) => {
       const [file] = files;
-      handleTranscript({
-        file,
-        language,
-        newLanguage,
-      }, 'upload');
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        if (!isValidSrt(e.target.result)) {
+          setInvalidSrtFile(true);
+        } else {
+          setInvalidSrtFile(false);
+          handleTranscript({
+            file,
+            language,
+            newLanguage,
+          }, 'upload');
+        }
+      };
+      reader.readAsText(file);
     },
     setSelectedRows: () => {},
     setAddOpen: () => {},
@@ -53,66 +74,78 @@ const Transcript = ({
 
   return (
     <>
-      {isConfirmationOpen ? (
-        <Card className="my-2">
-          <Card.Header className="h3" title={(<FormattedMessage {...messages.deleteConfirmationHeader} />)} />
-          <Card.Body>
-            <Card.Section>
-              <FormattedMessage {...messages.deleteConfirmationMessage} />
-            </Card.Section>
-            <Card.Footer>
-              <Button size="sm" variant="tertiary" className="mb-2 mb-sm-0" onClick={closeConfirmation}>
-                <FormattedMessage {...messages.cancelDeleteLabel} />
-              </Button>
-              <Button
-                variant="danger"
-                className="mb-2 mb-sm-0"
-                size="sm"
-                onClick={() => {
-                  handleTranscript({ language: transcript }, 'delete');
-                  closeConfirmation();
-                }}
-              >
-                <FormattedMessage {...messages.confirmDeleteLabel} />
-              </Button>
-            </Card.Footer>
-          </Card.Body>
-        </Card>
-      ) : (
-        <div
-          className="row m-0 align-items-center justify-content-between"
-          key={`transcript-${language}`}
-          data-testid={`transcript-${language}`}
-        >
-          <LanguageSelect
-            options={languages}
-            value={newLanguage}
-            placeholderText={intl.formatMessage(messages.languageSelectPlaceholder)}
-            previousSelection={previousSelection}
-            handleSelect={updateLangauge}
+      <div
+        className="row m-0 align-items-center justify-content-between"
+        key={`transcript-${language}`}
+        data-testid={`transcript-${language}`}
+      >
+        <LanguageSelect
+          options={languages}
+          value={newLanguage}
+          placeholderText={intl.formatMessage(messages.languageSelectPlaceholder)}
+          previousSelection={previousSelection}
+          handleSelect={updateLangauge}
+        />
+        { transcript === '' ? (
+          <IconButton
+            iconAs={Icon}
+            src={DeleteOutline}
+            onClick={openConfirmation}
+            alt="delete empty transcript"
           />
-          { transcript === '' ? (
-            <IconButton
-              iconAs={Icon}
-              src={DeleteOutline}
-              onClick={openConfirmation}
-              alt="delete empty transcript"
-            />
-          ) : (
-            <TranscriptMenu
-              {...{
-                language,
-                newLanguage,
-                setNewLanguage,
-                handleTranscript,
-                input,
-                launchDeleteConfirmation: openConfirmation,
-              }}
-            />
-          )}
-        </div>
+        ) : (
+          <TranscriptMenu
+            {...{
+              language,
+              newLanguage,
+              setNewLanguage,
+              handleTranscript,
+              input,
+              launchDeleteConfirmation: openConfirmation,
+              onEdit: setEditorLanguage,
+            }}
+          />
+        )}
+      </div>
+      {invalidSrtFile && (
+        <Stack direction="horizontal" gap={2} className="align-items-center text-danger-500 mt-1">
+          <Icon src={ErrorIcon} size="xs" />
+          <span className="small">{intl.formatMessage(sidebarMessages.invalidSrtFormat)}</span>
+        </Stack>
       )}
+      <AlertModal
+        title={<FormattedMessage {...messages.deleteConfirmationHeader} />}
+        isOpen={isConfirmationOpen}
+        onClose={closeConfirmation}
+        footerNode={(
+          <ActionRow>
+            <Button size="sm" variant="tertiary" onClick={closeConfirmation}>
+              <FormattedMessage {...messages.cancelDeleteLabel} />
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => {
+                handleTranscript({ language: transcript }, 'delete');
+                closeConfirmation();
+              }}
+            >
+              <FormattedMessage {...messages.confirmDeleteLabel} />
+            </Button>
+          </ActionRow>
+        )}
+      >
+        <p><FormattedMessage {...messages.deleteConfirmationMessage} /></p>
+      </AlertModal>
       <FileInput key="transcript-input" fileInput={input} supportedFileFormats={['.srt']} />
+      <TranscriptEditor
+        isOpen={Boolean(editorLanguage)}
+        onClose={() => setEditorLanguage('')}
+        video={video}
+        language={editorLanguage}
+        languages={languages}
+        transcriptSettings={transcriptSettings}
+      />
     </>
   );
 };
@@ -122,6 +155,15 @@ Transcript.propTypes = {
   transcript: PropTypes.string.isRequired,
   previousSelection: PropTypes.arrayOf(PropTypes.string).isRequired,
   handleTranscript: PropTypes.func.isRequired,
+  video: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    displayName: PropTypes.string.isRequired,
+    downloadLink: PropTypes.string,
+  }).isRequired,
+  transcriptSettings: PropTypes.shape({
+    transcriptDownloadHandlerUrl: PropTypes.string.isRequired,
+    transcriptUploadHandlerUrl: PropTypes.string.isRequired,
+  }).isRequired,
   // injected
   intl: intlShape.isRequired,
 };

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
@@ -12,6 +12,8 @@ import {
 } from '@openedx/paragon';
 import { MoreHoriz } from '@openedx/paragon/icons';
 
+import { useWaffleFlags } from '../../../../data/apiHooks';
+import { VideosPageContext } from '../../VideosPageProvider';
 import messages from './messages';
 
 export const TranscriptActionMenu = ({
@@ -19,9 +21,12 @@ export const TranscriptActionMenu = ({
   launchDeleteConfirmation,
   handleTranscript,
   input,
+  onEdit,
 }) => {
   const [isOpen, , close, toggle] = useToggle();
   const [target, setTarget] = useState(null);
+  const { courseId } = React.useContext(VideosPageContext);
+  const { enableTranscriptEditor } = useWaffleFlags(courseId);
   return (
     <>
       <IconButton
@@ -40,13 +45,26 @@ export const TranscriptActionMenu = ({
         onEscapeKey={close}
       >
         <Menu
-          className="transcript-menu"
+          className="transcript-menu overflow-hidden"
         >
+          {enableTranscriptEditor && (
+            <MenuItem
+              as={Button}
+              variant="tertiary"
+              key={`transcript-actions-${language}-edit`}
+              onClick={() => {
+                onEdit(language);
+                close();
+              }}
+            >
+              <FormattedMessage {...messages.editTranscript} />
+            </MenuItem>
+          )}
           <MenuItem
             as={Button}
             variant="tertiary"
             key={`transcript-actions-${language}-replace`}
-            onClick={input.click}
+            onClick={() => { input.click(); close(); }}
           >
             <FormattedMessage {...messages.replaceTranscript} />
           </MenuItem>
@@ -77,9 +95,14 @@ TranscriptActionMenu.propTypes = {
   language: PropTypes.string.isRequired,
   handleTranscript: PropTypes.func.isRequired,
   launchDeleteConfirmation: PropTypes.func.isRequired,
+  onEdit: PropTypes.func,
   input: PropTypes.shape({
     click: PropTypes.func.isRequired,
   }).isRequired,
+};
+
+TranscriptActionMenu.defaultProps = {
+  onEdit: () => {},
 };
 
 export default TranscriptActionMenu;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/messages.js
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/messages.js
@@ -1,6 +1,11 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
+  editTranscript: {
+    id: 'course-authoriong.video-uploads.file-info.transcript.editTranscript',
+    defaultMessage: 'Edit transcript',
+    description: 'Message Presented To user for action to edit transcript',
+  },
   fileSizeError: {
     id: 'course-authoriong.video-uploads.file-info.transcript.error.fileSizeError',
     defaultMessage: 'Transcript file size exeeds the maximum. Please try again.',

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.jsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.jsx
@@ -1,0 +1,566 @@
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  Alert,
+  Button,
+  Form,
+  Icon,
+  IconButton,
+  ModalDialog,
+  Spinner,
+  Stack,
+} from '@openedx/paragon';
+import {
+  Add,
+  CheckCircle,
+  DeleteOutline,
+  Info,
+  PlayArrow,
+} from '@openedx/paragon/icons';
+
+import { fetchTranscriptContent, uploadTranscript } from '../data/api';
+import {
+  formatTimestamp,
+  parseSrt,
+  parseTimestamp,
+  serializeSrt,
+} from './srtUtils';
+import messages from './messages';
+import './TranscriptEditor.scss';
+
+const toVttTimestamp = (timestamp) => timestamp.replace(',', '.');
+const TIMESTAMP_REGEX = /^\d{2}:\d{2}:\d{2},\d{3}$/;
+const hasInvalidCueText = (text = '') => {
+  const lines = text.split(/\r?\n/);
+  return text.trim().length === 0 || lines.some((line) => line.trim().length === 0);
+};
+
+const serializeVtt = (cues) => {
+  const body = cues
+    .map((cue, index) => `${index + 1}\n${toVttTimestamp(cue.startTime)} --> ${toVttTimestamp(cue.endTime)}\n${cue.text}`)
+    .join('\n\n');
+
+  return `WEBVTT\n\n${body}`;
+};
+
+const TranscriptEditor = ({
+  isOpen,
+  onClose,
+  video,
+  language,
+  languages,
+  transcriptSettings,
+}) => {
+  const intl = useIntl();
+  const videoRef = useRef(null);
+  const cueIdRef = useRef(0);
+  const cueTextRefs = useRef({});
+  const pendingFocusId = useRef(null);
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [cues, setCues] = useState([]);
+  const [captionTrackUrl, setCaptionTrackUrl] = useState('');
+  const [currentTime, setCurrentTime] = useState(0);
+  const [initialCuesSnapshot, setInitialCuesSnapshot] = useState('[]');
+  const [isUnsavedModalOpen, setIsUnsavedModalOpen] = useState(false);
+  const [saveStatus, setSaveStatus] = useState('idle');
+
+  const attachCueIds = (nextCues) => nextCues.map((cue) => ({
+    ...cue,
+    id: cue.id ?? `cue-${cueIdRef.current++}`,
+  }));
+
+  const serializeComparableCues = (nextCues) => JSON.stringify(nextCues.map((cue) => ({
+    startTime: cue.startTime,
+    endTime: cue.endTime,
+    text: cue.text,
+  })));
+
+  const hasUnsavedChanges = useMemo(
+    () => serializeComparableCues(cues) !== initialCuesSnapshot,
+    [cues, initialCuesSnapshot],
+  );
+
+  const hasInvalidCueTextInEditor = useMemo(
+    () => cues.some((cue) => hasInvalidCueText(cue.text)),
+    [cues],
+  );
+
+  const hasInvalidTimestamp = (cue) => (
+    !TIMESTAMP_REGEX.test(cue.startTime)
+    || !TIMESTAMP_REGEX.test(cue.endTime)
+    || parseTimestamp(cue.endTime) <= parseTimestamp(cue.startTime)
+  );
+
+  const hasInvalidTimestampsInEditor = useMemo(
+    () => cues.some(hasInvalidTimestamp),
+    [cues],
+  );
+
+  useEffect(() => {
+    if (pendingFocusId.current) {
+      const el = cueTextRefs.current[pendingFocusId.current];
+      if (el) {
+        el.focus();
+        pendingFocusId.current = null;
+      }
+    }
+  }, [cues]);
+
+  const inlineErrorMessage = saveError;
+
+  useEffect(() => {
+    if (!isOpen || !language) {
+      return undefined;
+    }
+
+    let isMounted = true;
+    setLoading(true);
+    setSaveError('');
+    setIsUnsavedModalOpen(false);
+    setCurrentTime(0);
+    setSaveStatus('idle');
+
+    fetchTranscriptContent({
+      videoId: video.id,
+      language,
+      apiUrl: transcriptSettings.transcriptDownloadHandlerUrl,
+    })
+      .then((text) => {
+        if (!isMounted) {
+          return undefined;
+        }
+        const parsedCues = parseSrt(text);
+        setCues(attachCueIds(parsedCues));
+        setInitialCuesSnapshot(serializeComparableCues(parsedCues));
+        return undefined;
+      })
+      .catch(() => {
+        if (!isMounted) {
+          return undefined;
+        }
+        setCues([]);
+        setInitialCuesSnapshot('[]');
+        setSaveError(intl.formatMessage(messages.saveFailedLabel));
+        return undefined;
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    isOpen,
+    language,
+    video.id,
+    transcriptSettings.transcriptDownloadHandlerUrl,
+    intl,
+  ]);
+
+  const handleCueChange = (index, value) => {
+    setCues(prev => prev.map((cue, cueIndex) => (
+      cueIndex === index ? { ...cue, text: value } : cue
+    )));
+  };
+
+  const handleCueTimeChange = (index, field, value) => {
+    const normalized = value
+      .replace(/\./g, ',')
+      .replace(/[^\d:,]/g, '')
+      .slice(0, 12);
+
+    setCues(prev => prev.map((cue, cueIndex) => (
+      cueIndex === index ? { ...cue, [field]: normalized } : cue
+    )));
+  };
+
+  const handleCueTimeBlur = (index, field, value) => {
+    const normalized = value.replace(/\./g, ',').trim();
+    if (!TIMESTAMP_REGEX.test(normalized)) {
+      return;
+    }
+
+    setCues(prev => prev.map((cue, cueIndex) => (
+      cueIndex === index
+        ? { ...cue, [field]: formatTimestamp(parseTimestamp(normalized)) }
+        : cue
+    )));
+  };
+
+  const handleDeleteCue = (index) => {
+    setCues(prev => prev.filter((_, cueIndex) => cueIndex !== index));
+  };
+
+  const handleInsertCueAfter = (index) => {
+    setCues((prev) => {
+      // index === -1 means insert as the very first cue (empty list)
+      if (index === -1) {
+        const newId = `cue-${cueIdRef.current++}`;
+        pendingFocusId.current = newId;
+        return [{
+          id: newId,
+          startTime: formatTimestamp(0),
+          endTime: formatTimestamp(2),
+          text: '',
+        }];
+      }
+
+      const currentCue = prev[index];
+      if (!currentCue) {
+        return prev;
+      }
+
+      const currentEnd = parseTimestamp(currentCue.endTime);
+      const nextStart = prev[index + 1]
+        ? parseTimestamp(prev[index + 1].startTime)
+        : currentEnd + 2;
+
+      const insertedStart = currentEnd;
+      const insertedEnd = nextStart > currentEnd ? Math.min(currentEnd + 2, nextStart) : currentEnd + 2;
+
+      const newId = `cue-${cueIdRef.current++}`;
+      pendingFocusId.current = newId;
+      const newCue = {
+        id: newId,
+        startTime: formatTimestamp(insertedStart),
+        endTime: formatTimestamp(insertedEnd),
+        text: '',
+      };
+
+      const updated = [...prev];
+      updated.splice(index + 1, 0, newCue);
+      return updated;
+    });
+  };
+
+  const seekTo = (timeCode) => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = parseTimestamp(timeCode);
+      videoRef.current.play();
+      setCurrentTime(parseTimestamp(timeCode));
+    }
+  };
+
+  const handleVideoTimeUpdate = (event) => {
+    setCurrentTime(event.currentTarget.currentTime);
+  };
+
+  useEffect(() => {
+    if (!cues.length) {
+      setCaptionTrackUrl('');
+      return undefined;
+    }
+
+    const vttBlob = new Blob([serializeVtt(cues)], { type: 'text/vtt' });
+    const nextUrl = URL.createObjectURL(vttBlob);
+    setCaptionTrackUrl(nextUrl);
+
+    return () => {
+      URL.revokeObjectURL(nextUrl);
+    };
+  }, [cues]);
+
+  useEffect(() => {
+    if (saveStatus !== 'saved') {
+      return undefined;
+    }
+
+    const timerId = setTimeout(() => {
+      setSaveStatus('idle');
+    }, 5000);
+
+    return () => clearTimeout(timerId);
+  }, [saveStatus]);
+
+  const handleSave = async () => {
+    const hasInvalidCueTextValue = cues.some((cue) => hasInvalidCueText(cue.text));
+    if (hasInvalidCueTextValue) {
+      return;
+    }
+
+    setSaving(true);
+    setSaveStatus('saving');
+    setSaveError('');
+
+    try {
+      const fileName = `${video.displayName}-${language}.srt`;
+      const file = new File([serializeSrt(cues)], fileName, { type: 'text/plain' });
+
+      await uploadTranscript({
+        videoId: video.id,
+        language,
+        newLanguage: language,
+        apiUrl: transcriptSettings.transcriptUploadHandlerUrl,
+        file,
+      });
+
+      setInitialCuesSnapshot(serializeComparableCues(cues));
+      setSaveStatus('saved');
+    } catch (error) {
+      setSaveStatus('idle');
+      setSaveError(intl.formatMessage(messages.saveFailedLabel));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRequestClose = () => {
+    if (saving) {
+      return;
+    }
+
+    if (hasUnsavedChanges) {
+      setIsUnsavedModalOpen(true);
+      return;
+    }
+
+    onClose(false);
+  };
+
+  return (
+    <ModalDialog
+      isOpen={isOpen}
+      onClose={handleRequestClose}
+      hasCloseButton
+      title={video.displayName}
+      size="xl"
+      className="transcript-editor-modal"
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          <div className="d-flex align-items-start justify-content-between w-100 transcript-editor-modal__header-row">
+            <div>
+              <h3 className="font-weight-bold h3 mb-0">{video.displayName}</h3>
+              <h6 className="small text-gray-700 mt-1">{languages?.[language] || language}</h6>
+            </div>
+            {saveStatus === 'saving' && (
+              <div className="d-inline-flex align-items-center text-gray-700 transcript-editor-modal__save-indicator">
+                <Spinner animation="border" size="sm" className="mr-2" screenReaderText={intl.formatMessage(messages.saveInProgressLabel)} />
+                <span>{intl.formatMessage(messages.saveInProgressLabel)}</span>
+              </div>
+            )}
+            {saveStatus === 'saved' && (
+              <div className="d-inline-flex align-items-center text-success transcript-editor-modal__save-indicator">
+                <Icon src={CheckCircle} className="mr-2" />
+                <span>{intl.formatMessage(messages.savedLabel)}</span>
+              </div>
+            )}
+          </div>
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+
+      <ModalDialog.Body className="px-0 pb-0 d-flex flex-column">
+        {inlineErrorMessage && (
+          <Alert variant="danger" icon={Info} className="mx-4 mt-3 mb-0 flex-shrink-0">
+            {inlineErrorMessage}
+          </Alert>
+        )}
+        {loading ? (
+          <div className="d-flex align-items-center justify-content-center py-5">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loadingLabel)} />
+          </div>
+        ) : (
+          <>
+            {video.downloadLink && (
+              <div className="flex-shrink-0 bg-black">
+                <video
+                  ref={videoRef}
+                  src={video.downloadLink}
+                  controls
+                  controlsList="nodownload"
+                  disablePictureInPicture
+                  onTimeUpdate={handleVideoTimeUpdate}
+                  onSeeked={handleVideoTimeUpdate}
+                  className="transcript-editor-modal__video"
+                >
+                  <track
+                    key={captionTrackUrl}
+                    kind="captions"
+                    src={captionTrackUrl || ''}
+                    srcLang={language}
+                    label={language.toUpperCase()}
+                    default
+                  />
+                </video>
+              </div>
+            )}
+
+            <div className="transcript-editor-modal__cue-list overflow-auto px-4 pb-2">
+              {cues.length === 0 && (
+                <div className="d-flex justify-content-center py-4">
+                  <Button
+                    variant="outline-primary"
+                    size="sm"
+                    iconBefore={Add}
+                    onClick={() => handleInsertCueAfter(-1)}
+                  >
+                    {intl.formatMessage(messages.insertCueLabel)}
+                  </Button>
+                </div>
+              )}
+              {cues.map((cue, index) => {
+                const isActive = currentTime >= parseTimestamp(cue.startTime)
+                  && currentTime < parseTimestamp(cue.endTime);
+                const hasCueTextError = hasInvalidCueText(cue.text);
+                return (
+                  <Stack key={cue.id ?? `cue-${index}`} gap={2} className={`py-2 transcript-editor-modal__cue-wrapper${isActive ? ' transcript-editor-modal__cue--active' : ''}`}>
+                    <Stack direction="horizontal" gap={2} className="transcript-editor-modal__cue-row">
+                      <div className="transcript-editor-modal__cue-text-wrap">
+                        <Form.Control
+                          type="text"
+                          value={cue.text}
+                          onChange={(e) => handleCueChange(index, e.target.value)}
+                          className="transcript-editor-modal__cue-text"
+                          isInvalid={hasCueTextError}
+                          ref={(el) => {
+                            if (el) { cueTextRefs.current[cue.id] = el; } else { delete cueTextRefs.current[cue.id]; }
+                          }}
+                        />
+                        {hasCueTextError && (
+                          <Form.Control.Feedback type="invalid" hasIcon={false}>
+                            {intl.formatMessage(messages.invalidCueTextLabel)}
+                          </Form.Control.Feedback>
+                        )}
+                      </div>
+                      <div className="transcript-editor-modal__time-wrap">
+                        <Form.Control
+                          size="sm"
+                          type="text"
+                          value={cue.startTime}
+                          className="transcript-editor-modal__time"
+                          onChange={(e) => handleCueTimeChange(index, 'startTime', e.target.value)}
+                          onBlur={(e) => handleCueTimeBlur(index, 'startTime', e.target.value)}
+                        />
+                      </div>
+                      <span className="transcript-editor-modal__time-sep">→</span>
+                      <div className="transcript-editor-modal__time-wrap">
+                        <Form.Control
+                          size="sm"
+                          type="text"
+                          value={cue.endTime}
+                          className="transcript-editor-modal__time"
+                          onChange={(e) => handleCueTimeChange(index, 'endTime', e.target.value)}
+                          onBlur={(e) => handleCueTimeBlur(index, 'endTime', e.target.value)}
+                        />
+                      </div>
+                      <IconButton
+                        iconAs={Icon}
+                        src={PlayArrow}
+                        alt={intl.formatMessage(messages.seekCueLabel)}
+                        onClick={() => seekTo(cue.startTime)}
+                      />
+                      <IconButton
+                        iconAs={Icon}
+                        src={DeleteOutline}
+                        alt={intl.formatMessage(messages.deleteCueLabel)}
+                        onClick={() => handleDeleteCue(index)}
+                      />
+                    </Stack>
+                    {hasInvalidTimestamp(cue) && (
+                      <div className="text-danger small mt-n1">
+                        {intl.formatMessage(messages.invalidTimestampLabel)}
+                      </div>
+                    )}
+                    <div className="transcript-editor-modal__insert-divider">
+                      <hr className="transcript-editor-modal__insert-divider-line" />
+                      <Button
+                        variant="light"
+                        size="sm"
+                        iconBefore={Add}
+                        className="transcript-editor-modal__insert-btn"
+                        onClick={() => handleInsertCueAfter(index)}
+                      >
+                        {intl.formatMessage(messages.insertCueLabel)}
+                      </Button>
+                    </div>
+                  </Stack>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <Button
+          variant="tertiary"
+          onClick={handleRequestClose}
+          disabled={saving}
+        >
+          {intl.formatMessage(messages.cancelButtonLabel)}
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={
+            saving || loading || !hasUnsavedChanges || hasInvalidCueTextInEditor || hasInvalidTimestampsInEditor
+          }
+        >
+          {saving
+            ? intl.formatMessage(messages.saveInProgressLabel)
+            : intl.formatMessage(messages.saveButtonLabel)}
+        </Button>
+      </ModalDialog.Footer>
+
+      {isUnsavedModalOpen && (
+        <ModalDialog
+          isOpen
+          size="md"
+          onClose={() => setIsUnsavedModalOpen(false)}
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>{intl.formatMessage(messages.unsavedModalTitle)}</ModalDialog.Title>
+          </ModalDialog.Header>
+          <ModalDialog.Body>
+            <p>{intl.formatMessage(messages.unsavedModalDescription)}</p>
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <Button variant="tertiary" onClick={() => setIsUnsavedModalOpen(false)}>
+              {intl.formatMessage(messages.keepEditingButtonLabel)}
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => {
+                setIsUnsavedModalOpen(false);
+                onClose(false);
+              }}
+            >
+              {intl.formatMessage(messages.closeEditorButtonLabel)}
+            </Button>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      )}
+    </ModalDialog>
+  );
+};
+
+TranscriptEditor.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  language: PropTypes.string,
+  languages: PropTypes.shape({}),
+  video: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    displayName: PropTypes.string.isRequired,
+    downloadLink: PropTypes.string,
+  }).isRequired,
+  transcriptSettings: PropTypes.shape({
+    transcriptDownloadHandlerUrl: PropTypes.string.isRequired,
+    transcriptUploadHandlerUrl: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+TranscriptEditor.defaultProps = {
+  language: '',
+  languages: {},
+};
+
+export default TranscriptEditor;

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
@@ -1,0 +1,177 @@
+.transcript-editor-modal {
+  &__header-row {
+    padding-right: 2rem;
+  }
+
+  &__save-indicator {
+    font-size: 0.875rem;
+    white-space: nowrap;
+    margin-top: 0.25rem;
+  }
+
+  &__video {
+    display: block;
+    width: 100%;
+    max-height: 320px;
+    background: var(--pgn-color-black);
+    object-fit: contain;
+  }
+
+  &.pgn__modal {
+    .pgn__modal-content-container {
+      display: flex;
+      flex-direction: column;
+      max-height: 90vh;
+    }
+  }
+
+  .pgn__modal-body {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    flex: 1 1 auto;
+    min-height: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+  }
+
+  &__cue-list {
+    max-height: calc(90vh - 500px);
+    min-height: 200px;
+  }
+
+  &__cue-wrapper {
+    &.transcript-editor-modal__cue--active {
+      background: linear-gradient(90deg, rgb(0 117 180 / 0.08) 0%, transparent 100%);
+      border-left: 3px solid var(--pgn-color-info-500);
+      border-radius: 0.25rem;
+
+      .transcript-editor-modal__cue-text.form-control {
+        color: var(--pgn-color-primary-500);
+        font-weight: 500;
+      }
+    }
+  }
+
+  &__cue-row {
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  &__cue-text-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+    position: relative;
+
+    .pgn__form-control-feedback {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      font-size: 0.75rem;
+      white-space: nowrap;
+      margin-top: 0.1rem;
+    }
+  }
+
+  &__cue-text.form-control {
+    font-size: 0.875rem;
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.4rem;
+    border: 1px solid transparent !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    transition: border-color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover {
+      border: 1px solid var(--pgn-color-gray-300) !important;
+      background: transparent !important;
+      box-shadow: none !important;
+    }
+
+    &:focus {
+      border: 1px solid var(--pgn-color-info-500) !important;
+      background: var(--pgn-color-white) !important;
+      box-shadow: 0 0 0 2px rgb(0 117 180 / 0.2) !important;
+      outline: none !important;
+    }
+
+    &.is-invalid {
+      border: 1px solid var(--pgn-color-danger-500) !important;
+      background: var(--pgn-color-danger-100) !important;
+      box-shadow: none !important;
+    }
+  }
+
+
+
+  &__time-wrap {
+    flex: 0 0 auto;
+    width: 8rem;
+
+    .pgn__form-control-decorator-group {
+      width: 100%;
+    }
+  }
+
+  &__time.form-control {
+    width: 100%;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.65rem;
+    padding: 0.15rem 0.25rem;
+    height: auto;
+    border: 1px solid var(--pgn-color-gray-300);
+    border-radius: 0.25rem;
+    color: var(--pgn-color-gray-700);
+    background: var(--pgn-color-white);
+
+    &:focus {
+      outline: none;
+      border-color: var(--pgn-color-info-500);
+      box-shadow: 0 0 0 2px rgb(0 117 180 / 0.2);
+    }
+  }
+
+  &__time-sep {
+    color: var(--pgn-color-gray-500);
+    flex-shrink: 0;
+  }
+
+  &__cue-row .btn-icon {
+    flex-shrink: 0;
+  }
+
+  &__insert-divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: 100%;
+    height: 2rem;
+    visibility: hidden;
+  }
+
+  &__insert-divider-line {
+    width: 100%;
+    position: absolute;
+    margin: 0;
+    border: 0;
+    border-top: 1px dashed var(--pgn-color-light-500);
+    z-index: 0;
+  }
+
+  &__insert-btn.btn {
+    background: var(--pgn-color-white);
+    border: 1px dashed var(--pgn-color-gray-500);
+    color: var(--pgn-color-gray-700);
+    font-size: 0.75rem;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    position: relative;
+    z-index: 1;
+  }
+
+  &__cue-wrapper:hover &__insert-divider {
+    visibility: visible;
+  }
+}

--- a/src/files-and-videos/videos-page/transcript-editor/index.js
+++ b/src/files-and-videos/videos-page/transcript-editor/index.js
@@ -1,0 +1,1 @@
+export { default } from './TranscriptEditor';

--- a/src/files-and-videos/videos-page/transcript-editor/messages.js
+++ b/src/files-and-videos/videos-page/transcript-editor/messages.js
@@ -1,0 +1,81 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  loadingLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.loading',
+    defaultMessage: 'Loading transcript...',
+    description: 'Loading state for transcript editor',
+  },
+  saveButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.save',
+    defaultMessage: 'Save',
+    description: 'Save button label for transcript editor',
+  },
+  cancelButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button label for transcript editor',
+  },
+  saveFailedLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.saveFailed',
+    defaultMessage: 'Unable to save transcript, please try again.',
+    description: 'Error shown when transcript save fails',
+  },
+  saveInProgressLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.saving',
+    defaultMessage: 'Saving...',
+    description: 'Label shown while transcript save is in progress',
+  },
+  savedLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.saved',
+    defaultMessage: 'Saved',
+    description: 'Label shown when transcript save is successful',
+  },
+  insertCueLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.insertCue',
+    defaultMessage: 'Insert cue here',
+    description: 'Label for inserting a new cue between transcript cues',
+  },
+  deleteCueLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.deleteCue',
+    defaultMessage: 'Delete cue',
+    description: 'Accessible label for deleting a transcript cue',
+  },
+  seekCueLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.seekCue',
+    defaultMessage: 'Seek to cue time',
+    description: 'Accessible label for seek button in cue row',
+  },
+  invalidTimestampLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.invalidTimestamp',
+    defaultMessage: 'Please use valid cue times in HH:MM:SS,mmm format.',
+    description: 'Error shown when one or more cue timestamps are invalid',
+  },
+  unsavedModalTitle: {
+    id: 'course-authoring.video-uploads.transcriptEditor.unsavedModalTitle',
+    defaultMessage: 'Unsaved changes',
+    description: 'Title for unsaved changes warning modal',
+  },
+  unsavedModalDescription: {
+    id: 'course-authoring.video-uploads.transcriptEditor.unsavedModalDescription',
+    defaultMessage: 'Are you sure you want to leave the editor? All unsaved changes will be lost.',
+    description: 'Description for unsaved changes warning modal',
+  },
+  keepEditingButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.keepEditing',
+    defaultMessage: 'Keep editing',
+    description: 'Button label to keep editing transcript changes',
+  },
+  closeEditorButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.closeEditor',
+    defaultMessage: 'Leave editor',
+    description: 'Button label to close transcript editor and discard changes',
+  },
+  invalidCueTextLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.invalidCueText',
+    defaultMessage: 'Cue text cannot be empty.',
+    description: 'Error shown when one or more cue texts are empty',
+  },
+});
+
+export default messages;

--- a/src/files-and-videos/videos-page/transcript-editor/srtUtils.js
+++ b/src/files-and-videos/videos-page/transcript-editor/srtUtils.js
@@ -1,0 +1,83 @@
+export const parseSrt = (text) => {
+  if (!text || typeof text !== 'string') {
+    return [];
+  }
+
+  return text
+    .trim()
+    .split(/\n\s*\n/)
+    .map((block) => block.split('\n'))
+    .map((lines) => {
+      if (lines.length < 2) {
+        return null;
+      }
+
+      const hasIndex = /^\d+$/.test(lines[0].trim());
+      const timeLine = hasIndex ? lines[1] : lines[0];
+      const textLines = hasIndex ? lines.slice(2) : lines.slice(1);
+
+      const match = timeLine.match(/(\d{2}:\d{2}:\d{2},\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2},\d{3})/);
+      if (!match) {
+        return null;
+      }
+
+      return {
+        startTime: match[1],
+        endTime: match[2],
+        text: textLines.join('\n').trim(),
+      };
+    })
+    .filter(Boolean);
+};
+
+export const serializeSrt = (cues) => cues
+  .map((cue, index) => `${index + 1}\n${cue.startTime} --> ${cue.endTime}\n${cue.text}`)
+  .join('\n\n');
+
+export const parseTimestamp = (timestamp) => {
+  const [hms, ms] = timestamp.split(',');
+  const [hours, minutes, seconds] = hms.split(':').map(Number);
+  return (hours * 3600) + (minutes * 60) + seconds + (Number(ms || 0) / 1000);
+};
+
+export const formatTimestamp = (totalSeconds) => {
+  const safeSeconds = Math.max(0, Number(totalSeconds) || 0);
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const seconds = Math.floor(safeSeconds % 60);
+  const milliseconds = Math.round((safeSeconds - Math.floor(safeSeconds)) * 1000);
+
+  const pad2 = (value) => String(value).padStart(2, '0');
+  const pad3 = (value) => String(value).padStart(3, '0');
+
+  return `${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)},${pad3(milliseconds)}`;
+};
+
+/**
+ * Strictly validates SRT content.
+ * Returns true for empty/blank files (valid empty transcript).
+ * Returns false if the file has cue blocks where ANY block has a malformed
+ * timestamp line (partial corruption is not allowed).
+ */
+export const isValidSrt = (text) => {
+  if (!text || typeof text !== 'string') {
+    return true;
+  }
+
+  const blocks = text.trim().split(/\n\s*\n/).filter((b) => b.trim().length > 0);
+  if (blocks.length === 0) {
+    return true;
+  }
+
+  const TIMESTAMP_LINE = /^\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
+
+  return blocks.every((block) => {
+    const lines = block.trim().split('\n').map((l) => l.trim());
+    if (lines.length < 2) {
+      return false;
+    }
+    const hasIndex = /^\d+$/.test(lines[0]);
+    const timeLine = hasIndex ? lines[1] : lines[0];
+    return TIMESTAMP_LINE.test(timeLine);
+  });
+};


### PR DESCRIPTION
## Description

Implements the In-Platform Transcript Editor for the Videos page in Studio
(`frontend-app-authoring`). Course authors can now edit and auto-save SRT
transcripts directly within Studio - without downloading, editing locally,
and re-uploading.

---

# Demo - Screen Recording 

https://github.com/user-attachments/assets/fae8c752-edf3-4eee-81fa-9392327c7dbe



---

## Testing

### Manual
- [x] Open Videos page (List view) → transcript count shown as a
  clickable link → clicking opens the info modal
- [x] In info modal → click `⋯ → Edit transcript` → transcript
  editor opens
- [x] Edit transcript cue text → "Saving…" spinner appears →
  "✅ Saved" shown on success
- [x] Simulate save failure → error shown in editor header
- [x] Click `+ Add a transcript` → language dropdown and Upload
  file button shown
- [x] Upload a valid `.srt` file → file confirmed → "Add transcript"
  button enables → transcript count updates → success toast appears
- [x] Upload a file > 25MB → inline size error shown before upload
- [x] Upload an invalid (non-SRT) file → inline format error shown
- [x] Toggle `enableTranscriptEditor` waffle flag OFF →
  "Edit transcript" option disappears from `⋯` menu
- [x] Verify existing Download, Replace, Delete transcript flows
  are unaffected
- [x] Open Videos page (Grid view) → `⋯ → Info and transcripts`
  menu label is correct

---

## Waffle Flag

`enableTranscriptEditor` (default: `false`)

Registered in `src/data/api.ts` → `waffleFlagDefaults`.
Enable via Django Admin or MFE config to expose the editor UI.

---

## New API

```
GET /transcripts/?edx_video_id={videoId}&language_code={language}
```

---

Backend PR: 
- PR :  https://github.com/edx/edx-platform/pull/267
---


Jira ticket:
- https://2u-internal.atlassian.net/browse/TNL2-515

 