### PR TITLE
fix(transcript-editor): add active cue auto-scroll and responsive modal layout fixes

### DIFF
--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.jsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.jsx
@@ -57,6 +57,8 @@ const TranscriptEditor = ({
   const intl = useIntl();
   const videoRef = useRef(null);
   const cueIdRef = useRef(0);
+  const cueListRef = useRef(null);
+  const cueWrapperRefs = useRef({});
   const cueTextRefs = useRef({});
   const pendingFocusId = useRef(null);
 
@@ -102,6 +104,17 @@ const TranscriptEditor = ({
     [cues],
   );
 
+  const activeCueId = useMemo(() => {
+    const activeCue = cues.find((cue) => (
+      TIMESTAMP_REGEX.test(cue.startTime)
+      && TIMESTAMP_REGEX.test(cue.endTime)
+      && currentTime >= parseTimestamp(cue.startTime)
+      && currentTime < parseTimestamp(cue.endTime)
+    ));
+
+    return activeCue?.id || null;
+  }, [cues, currentTime]);
+
   useEffect(() => {
     if (pendingFocusId.current) {
       const el = cueTextRefs.current[pendingFocusId.current];
@@ -111,6 +124,31 @@ const TranscriptEditor = ({
       }
     }
   }, [cues]);
+
+  useEffect(() => {
+    const cueList = cueListRef.current;
+    const activeCue = activeCueId ? cueWrapperRefs.current[activeCueId] : null;
+
+    if (!cueList || !activeCue) {
+      return;
+    }
+
+    const cueListRect = cueList.getBoundingClientRect();
+    const activeCueRect = activeCue.getBoundingClientRect();
+    const nextScrollTop = cueList.scrollTop
+      + activeCueRect.top
+      - cueListRect.top
+      - ((cueListRect.height - activeCueRect.height) / 2);
+
+    if (typeof cueList.scrollTo === 'function') {
+      cueList.scrollTo({
+        top: Math.max(0, nextScrollTop),
+        behavior: 'smooth',
+      });
+    } else {
+      cueList.scrollTop = Math.max(0, nextScrollTop);
+    }
+  }, [activeCueId]);
 
   const inlineErrorMessage = saveError;
 
@@ -337,19 +375,19 @@ const TranscriptEditor = ({
     >
       <ModalDialog.Header>
         <ModalDialog.Title>
-          <div className="d-flex align-items-start justify-content-between w-100 transcript-editor-modal__header-row">
+          <div className="d-flex align-items-start justify-content-between w-100 pr-4">
             <div>
               <h3 className="font-weight-bold h3 mb-0">{video.displayName}</h3>
               <h6 className="small text-gray-700 mt-1">{languages?.[language] || language}</h6>
             </div>
             {saveStatus === 'saving' && (
-              <div className="d-inline-flex align-items-center text-gray-700 transcript-editor-modal__save-indicator">
+              <div className="d-inline-flex align-items-center text-gray-700 small text-nowrap mt-1">
                 <Spinner animation="border" size="sm" className="mr-2" screenReaderText={intl.formatMessage(messages.saveInProgressLabel)} />
                 <span>{intl.formatMessage(messages.saveInProgressLabel)}</span>
               </div>
             )}
             {saveStatus === 'saved' && (
-              <div className="d-inline-flex align-items-center text-success transcript-editor-modal__save-indicator">
+              <div className="d-inline-flex align-items-center text-success small text-nowrap mt-1">
                 <Icon src={CheckCircle} className="mr-2" />
                 <span>{intl.formatMessage(messages.savedLabel)}</span>
               </div>
@@ -358,20 +396,20 @@ const TranscriptEditor = ({
         </ModalDialog.Title>
       </ModalDialog.Header>
 
-      <ModalDialog.Body className="px-0 pb-0 d-flex flex-column">
+      <ModalDialog.Body className="p-0 d-flex flex-column overflow-hidden">
         {inlineErrorMessage && (
           <Alert variant="danger" icon={Info} className="mx-4 mt-3 mb-0 flex-shrink-0">
             {inlineErrorMessage}
           </Alert>
         )}
         {loading ? (
-          <div className="d-flex align-items-center justify-content-center py-5">
+          <div className="d-flex align-items-center justify-content-center py-5 flex-fill">
             <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loadingLabel)} />
           </div>
         ) : (
           <>
             {video.downloadLink && (
-              <div className="flex-shrink-0 bg-black">
+              <div className="transcript-editor-modal__video-container bg-black d-flex align-items-center justify-content-center flex-shrink-0 overflow-hidden">
                 <video
                   ref={videoRef}
                   src={video.downloadLink}
@@ -394,7 +432,7 @@ const TranscriptEditor = ({
               </div>
             )}
 
-            <div className="transcript-editor-modal__cue-list overflow-auto px-4 pb-2">
+            <div ref={cueListRef} className="transcript-editor-modal__cue-list overflow-auto flex-grow-1 px-4 py-3">
               {cues.length === 0 && (
                 <div className="d-flex justify-content-center py-4">
                   <Button
@@ -408,13 +446,23 @@ const TranscriptEditor = ({
                 </div>
               )}
               {cues.map((cue, index) => {
-                const isActive = currentTime >= parseTimestamp(cue.startTime)
-                  && currentTime < parseTimestamp(cue.endTime);
+                const isActive = activeCueId === cue.id;
                 const hasCueTextError = hasInvalidCueText(cue.text);
                 return (
-                  <Stack key={cue.id ?? `cue-${index}`} gap={2} className={`py-2 transcript-editor-modal__cue-wrapper${isActive ? ' transcript-editor-modal__cue--active' : ''}`}>
-                    <Stack direction="horizontal" gap={2} className="transcript-editor-modal__cue-row">
-                      <div className="transcript-editor-modal__cue-text-wrap">
+                  <Stack
+                    key={cue.id ?? `cue-${index}`}
+                    ref={(el) => {
+                      if (el) {
+                        cueWrapperRefs.current[cue.id] = el;
+                      } else {
+                        delete cueWrapperRefs.current[cue.id];
+                      }
+                    }}
+                    gap={2}
+                    className={`px-3 py-2 transcript-editor-modal__cue-wrapper${isActive ? ' transcript-editor-modal__cue--active' : ''}`}
+                  >
+                    <Stack direction="horizontal" gap={2} className="transcript-editor-modal__cue-row flex-wrap flex-lg-nowrap align-items-center">
+                      <div className="transcript-editor-modal__cue-text-wrap flex-grow-1">
                         <Form.Control
                           type="text"
                           value={cue.text}

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
@@ -1,35 +1,40 @@
 .transcript-editor-modal {
-  &__header-row {
-    padding-right: 2rem;
-  }
-
-  &__save-indicator {
-    font-size: 0.875rem;
-    white-space: nowrap;
-    margin-top: 0.25rem;
+  &__video-container {
+    background: var(--pgn-color-black);
+    height: clamp(8rem, 40vh, 32rem);
   }
 
   &__video {
     display: block;
     width: 100%;
-    max-height: 320px;
+    max-height: 100%;
+    max-width: 100%;
     background: var(--pgn-color-black);
     object-fit: contain;
   }
 
   &.pgn__modal {
-    .pgn__modal-content-container {
-      display: flex;
-      flex-direction: column;
-      max-height: 90vh;
+    width: 80vw;
+    max-width: 80vw;
+    height: 95vh;
+    max-height: 95vh;
+    overflow: hidden;
+
+    .pgn__modal-header,
+    .pgn__modal-footer {
+      flex: 0 0 auto;
     }
   }
 
   .pgn__modal-body {
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
     flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .pgn__modal-body-content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
     min-height: 0;
     padding-left: 0;
     padding-right: 0;
@@ -37,19 +42,33 @@
   }
 
   &__cue-list {
-    max-height: calc(90vh - 500px);
-    min-height: 200px;
+    min-height: 0;
+    overscroll-behavior: contain;
+    scroll-behavior: smooth;
   }
 
   &__cue-wrapper {
+    border-left: 3px solid transparent;
+    border-radius: 0.375rem;
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+    transition: border-color 0.15s ease;
+
     &.transcript-editor-modal__cue--active {
       background: linear-gradient(90deg, rgb(0 117 180 / 0.08) 0%, transparent 100%);
       border-left: 3px solid var(--pgn-color-info-500);
       border-radius: 0.25rem;
+      box-shadow: 0 0 0 2px rgb(0 117 180 / 0.2);    
 
       .transcript-editor-modal__cue-text.form-control {
-        color: var(--pgn-color-primary-500);
+        border-color: var(--pgn-color-info-500) !important;
+        background: var(--pgn-color-white) !important;
+        color: var(--pgn-color-gray-900);
         font-weight: 500;
+      }
+
+      .transcript-editor-modal__time.form-control {
+         border-color: var(--pgn-color-info-500);
+         color: var(--pgn-color-gray-900);
       }
     }
   }
@@ -103,8 +122,6 @@
     }
   }
 
-
-
   &__time-wrap {
     flex: 0 0 auto;
     width: 8rem;
@@ -147,8 +164,9 @@
     justify-content: center;
     position: relative;
     width: 100%;
-    height: 2rem;
+    height: 0;
     visibility: hidden;
+    transition: height 0.15s ease;
   }
 
   &__insert-divider-line {
@@ -172,6 +190,28 @@
   }
 
   &__cue-wrapper:hover &__insert-divider {
+    height: 2rem;
     visibility: visible;
+  }
+
+  @media (width <= 767.98px) {
+    &.pgn__modal {
+      width: calc(100vw - 1rem);
+      max-width: calc(100vw - 1rem);
+      height: calc(100vh - 0.5rem);
+      max-height: calc(100vh - 0.5rem);
+      margin: 0;
+    }
+  }
+
+  @media (width <= 991.98px) {
+    &__cue-text-wrap {
+      flex-basis: 100%;
+    }
+
+    &__time-wrap {
+      flex: 1 1 7.5rem;
+      max-width: 9rem;
+    }
   }
 }


### PR DESCRIPTION
# Description

This PR improves the In-Platform Transcript Editor by introducing active cue tracking with auto-scroll, refining the cue DOM management with per-cue refs, and fixing the modal layout so the cue list properly fills and scrolls within the dialog without overflowing.

Impacts: Course Authors using the transcript editor while a video is playing.

### TranscriptEditor.jsx
- Added automatic scrolling to keep the active transcript cue centered during video playback.
- Introduced refs for cue list container and individual cue wrappers for scroll handling.
- Added `activeCueId` memoized calculation based on current playback time.
- Improved modal and cue list layout using flex utilities and responsive spacing classes.
- Updated cue list container to better fill available modal space.
- Minor JSX cleanup by replacing custom classes with utility classes.

### TranscriptEditor.scss
- Refactored modal layout to use a responsive flex-based structure.
- Improved cue list sizing and scrolling behavior.
- Added responsive video container with adaptive height handling.
- Updated video styling to use `object-fit: contain`.
- Simplified active cue and transition styles.
- Improved insert divider visibility behavior on hover.
- Added responsive breakpoints for smaller screen layouts.
- Removed unused/redundant BEM modifier styles and unnecessary overrides.

# Supporting information
- Jira ticket: [TNL2-636](https://apphelix.atlassian.net/browse/TNL2-636)

## Testing instructions
- Open Studio and navigate to a course with videos that have transcripts.
- Open the Transcript Editor for a video with multiple transcript cues.
- Play the video - confirm the active cue is highlighted with a left-border accent and the list auto-scrolls to keep it centered.
- Pause and seek to different timestamps - confirm the highlight and scroll update correctly.
- Add a new cue and confirm focus moves to it after insertion.
- Resize the browser to mobile width (< 768px) - confirm the modal fills the viewport and the cue row wraps correctly.
Confirm no layout overflow occurs on the modal body (cue list should scroll, not push the dialog taller).

# Screen-Recording:
https://github.com/user-attachments/assets/bbfefe1f-da92-4f42-bb50-5244d13c4285



