### PR TITLE
fix(course-outline): keep authors on outline after adding new unit

### DIFF
--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -38,6 +38,7 @@ import {
   addNewSectionQuery,
   addNewSubsectionQuery,
   addNewUnitQuery,
+  fetchCourseSectionQuery,
   deleteCourseSectionQuery,
   deleteCourseSubsectionQuery,
   deleteCourseUnitQuery,
@@ -145,13 +146,58 @@ const useCourseOutline = ({ courseId }) => {
   };
 
   const handleNewUnitSubmit = (subsectionId) => {
-    dispatch(addNewUnitQuery(subsectionId, openUnitPage));
+    const parentSection = sectionsList && sectionsList.find(
+      (section) => (
+        section.childInfo
+        && section.childInfo.children
+        && section.childInfo.children.some(
+          (child) => child.id === subsectionId,
+        )
+      ),
+    );
+
+    const parentSectionId = parentSection ? parentSection.id : null;
+
+    dispatch(addNewUnitQuery(subsectionId, (locator) => {
+      if (parentSectionId) {
+        dispatch(
+          fetchCourseSectionQuery(
+            [parentSectionId],
+            { subsectionId, unitId: locator },
+          ),
+        );
+      } else {
+        dispatch(fetchCourseOutlineIndexQuery(courseId));
+      }
+    }));
   };
 
-  /**
-  * import a unit block from library and redirect user to this unit page.
-  */
-  const handleAddUnitFromLibrary = useCreateCourseBlock(openUnitPage);
+  const handleAddUnitFromLibrary = useCreateCourseBlock(
+    (locator, parentLocator) => {
+      const parentSection = sectionsList && sectionsList.find(
+        (section) => (
+          section.childInfo
+        && section.childInfo.children
+        && section.childInfo.children.some(
+          (child) => child.id === parentLocator,
+        )
+        ),
+      );
+
+      const parentSectionId = parentSection ? parentSection.id : null;
+
+      if (parentSectionId) {
+        dispatch(
+          fetchCourseSectionQuery(
+            [parentSectionId],
+            { subsectionId: parentLocator, unitId: locator },
+          ),
+        );
+      } else {
+        dispatch(fetchCourseOutlineIndexQuery(courseId));
+      }
+    },
+  );
 
   const handleAddSubsectionFromLibrary = useCreateCourseBlock(async (locator, parentLocator) => {
     try {


### PR DESCRIPTION
## Summary

Updates the course outline flow to keep authors on the Outline page after adding or importing a Unit instead of redirecting to the Unit page.

## Technical Changes

* Replaced `openUnitPage` navigation callback in `addNewUnitQuery` with an inline refresh handler
* Added parent section lookup logic using `sectionsList` to identify the affected section/subsection
* Introduced `fetchCourseSectionQuery` to selectively refetch and update only the impacted section
* Added fallback to `fetchCourseOutlineIndexQuery(courseId)` when parent section resolution fails
* Applied the same refresh behavior to `useCreateCourseBlock` flow for Units imported from the library

## Result

Course authors can now add or import Units directly from the Outline while preserving their current editing context and keeping the outline state updated in place.

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-605

## Screen-Recording:

https://github.com/user-attachments/assets/a6728260-f1ab-4ef3-bc22-3b41c25f8e2d



- 