### PR TITLE
feat(course-outline): implement ComponentMenu for xblock-components

### DIFF
--- a/src/course-outline/unit-card/ComponentMenu.test.tsx
+++ b/src/course-outline/unit-card/ComponentMenu.test.tsx
@@ -1,0 +1,123 @@
+import {
+  act, fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+
+import cardHeaderMessages from '@src/course-outline/card-header/messages';
+import ComponentMenu from './ComponentMenu';
+
+const mockCopyToClipboard = jest.fn();
+const mockDeleteComponent = jest.fn();
+const mockDuplicateComponent = jest.fn();
+const mockOnActionComplete = jest.fn();
+
+jest.mock('@src/generic/clipboard', () => ({
+  useClipboard: () => ({
+    copyToClipboard: mockCopyToClipboard,
+  }),
+}));
+
+jest.mock('./data/hooks', () => ({
+  useDeleteUnitComponent: () => ({
+    mutateAsync: mockDeleteComponent,
+  }),
+  useDuplicateUnitComponent: () => ({
+    mutateAsync: mockDuplicateComponent,
+  }),
+}));
+
+const renderComponentMenu = (props?: Partial<React.ComponentProps<typeof ComponentMenu>>) => render(
+  <ComponentMenu
+    unitId="block-v1:test+type@vertical+block@unit1"
+    blockId="block-v1:test+type@html+block@1"
+    displayName="Test Component"
+    blockType="html"
+    actions={{
+      canCopy: true,
+      canDuplicate: true,
+      canDelete: true,
+      canMove: false,
+      canManageAccess: false,
+    }}
+    onActionComplete={mockOnActionComplete}
+    {...props}
+  />,
+);
+
+describe('<ComponentMenu />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    jest.clearAllMocks();
+    mockDeleteComponent.mockResolvedValue(undefined);
+    mockDuplicateComponent.mockResolvedValue(undefined);
+  });
+
+  const openMenu = async () => {
+    const toggle = screen.getByTestId('component-menu-toggle');
+    await act(async () => fireEvent.click(toggle));
+  };
+
+  it('renders copy, duplicate, and delete menu items', async () => {
+    renderComponentMenu();
+    await openMenu();
+
+    expect(screen.getByTestId('component-menu-copy')).toHaveTextContent(
+      cardHeaderMessages.menuCopy.defaultMessage,
+    );
+    expect(screen.getByTestId('component-menu-duplicate')).toHaveTextContent(
+      cardHeaderMessages.menuDuplicate.defaultMessage,
+    );
+    expect(screen.getByTestId('component-menu-delete')).toHaveTextContent(
+      cardHeaderMessages.menuDelete.defaultMessage,
+    );
+  });
+
+  it('copies the component to the clipboard', async () => {
+    renderComponentMenu();
+    await openMenu();
+
+    await act(async () => fireEvent.click(screen.getByTestId('component-menu-copy')));
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('block-v1:test+type@html+block@1');
+  });
+
+  it('duplicates the component and refreshes the unit', async () => {
+    renderComponentMenu();
+    await openMenu();
+
+    await act(async () => fireEvent.click(screen.getByTestId('component-menu-duplicate')));
+
+    await waitFor(() => {
+      expect(mockDuplicateComponent).toHaveBeenCalledWith('block-v1:test+type@html+block@1');
+      expect(mockOnActionComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('deletes the component after confirmation', async () => {
+    renderComponentMenu();
+    await openMenu();
+
+    await act(async () => fireEvent.click(screen.getByTestId('component-menu-delete')));
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await act(async () => fireEvent.click(deleteButton));
+
+    await waitFor(() => {
+      expect(mockDeleteComponent).toHaveBeenCalledWith('block-v1:test+type@html+block@1');
+      expect(mockOnActionComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('does not render when no actions are available', () => {
+    renderComponentMenu({
+      actions: {
+        canCopy: false,
+        canDuplicate: false,
+        canDelete: false,
+        canMove: false,
+        canManageAccess: false,
+      },
+    });
+
+    expect(screen.queryByTestId('component-menu')).not.toBeInTheDocument();
+  });
+});

--- a/src/course-outline/unit-card/ComponentMenu.tsx
+++ b/src/course-outline/unit-card/ComponentMenu.tsx
@@ -1,0 +1,278 @@
+import {
+  useCallback, useContext, useState,
+} from 'react';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import {
+  Dropdown,
+  Icon,
+  IconButton,
+  useToggle,
+} from '@openedx/paragon';
+import { MoreVert } from '@openedx/paragon/icons';
+
+import cardHeaderMessages from '@src/course-outline/card-header/messages';
+import { PUBLISH_TYPES } from '@src/course-unit/constants';
+import { editCourseUnitVisibilityAndData } from '@src/course-unit/data/thunk';
+import MoveModal from '@src/course-unit/move-modal';
+import type { IMoveRequestPayload } from '@src/course-unit/move-modal/interfaces';
+import { formatAccessManagedXBlockData } from '@src/course-unit/xblock-container-iframe/utils';
+import type { FormattedAccessManagedXBlockDataTypes, XBlockTypes } from '@src/course-unit/xblock-container-iframe/types';
+import ConfigureModal from '@src/generic/configure-modal/ConfigureModal';
+import DeleteModal from '@src/generic/delete-modal/DeleteModal';
+import { IframeProvider } from '@src/generic/hooks/context/iFrameContext';
+import { useClipboard } from '@src/generic/clipboard';
+import { ToastContext } from '@src/generic/toast-context';
+import moveModalMessages from '@src/course-unit/move-modal/messages';
+
+import type { UnitComponentActions } from './data/api';
+import { useDeleteUnitComponent, useDuplicateUnitComponent } from './data/hooks';
+import messages from './messages';
+
+interface ComponentMenuProps {
+  unitId: string;
+  blockId: string;
+  displayName: string;
+  blockType: string;
+  userPartitionInfo?: XBlockTypes['userPartitionInfo'];
+  userPartitions?: XBlockTypes['userPartitions'];
+  actions: UnitComponentActions;
+  onActionComplete: (targetUnitId?: string) => void;
+}
+
+const stopMenuEvent = (event: React.SyntheticEvent) => {
+  event.stopPropagation();
+};
+
+const ComponentMenu = ({
+  unitId,
+  blockId,
+  displayName,
+  blockType,
+  userPartitionInfo,
+  userPartitions,
+  actions,
+  onActionComplete,
+}: ComponentMenuProps) => {
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const { courseId } = useParams();
+  const { showToast } = useContext(ToastContext);
+  const { copyToClipboard } = useClipboard();
+  const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
+  const [isConfigureModalOpen, openConfigureModal, closeConfigureModal] = useToggle(false);
+  const [isMoveModalOpen, openMoveModal, closeMoveModal] = useToggle(false);
+  const [moveRequest, setMoveRequest] = useState<IMoveRequestPayload | null>(null);
+  const [configureItemData, setConfigureItemData] = useState<FormattedAccessManagedXBlockDataTypes | null>(null);
+  const { mutateAsync: deleteComponent } = useDeleteUnitComponent(unitId);
+  const { mutateAsync: duplicateComponent } = useDuplicateUnitComponent(unitId);
+
+  const handleManageAccess = useCallback((event: React.MouseEvent) => {
+    stopMenuEvent(event);
+    setConfigureItemData(formatAccessManagedXBlockData({
+      name: displayName,
+      blockType,
+      blockId,
+      id: blockId,
+      userPartitionInfo,
+      userPartitions,
+    } as XBlockTypes, blockId));
+    openConfigureModal();
+  }, [
+    blockId,
+    blockType,
+    displayName,
+    openConfigureModal,
+    userPartitionInfo,
+    userPartitions,
+  ]);
+
+  const handleConfigureSubmit = useCallback((
+    isVisible: boolean,
+    groupAccess: unknown,
+    isDiscussionEnabled: boolean,
+  ) => {
+    dispatch(editCourseUnitVisibilityAndData(
+      blockId,
+      PUBLISH_TYPES.republish,
+      isVisible,
+      groupAccess,
+      isDiscussionEnabled,
+      onActionComplete,
+      unitId,
+    ));
+    closeConfigureModal();
+    setConfigureItemData(null);
+  }, [blockId, closeConfigureModal, dispatch, onActionComplete, unitId]);
+
+  const handleConfigureClose = useCallback(() => {
+    closeConfigureModal();
+    setConfigureItemData(null);
+  }, [closeConfigureModal]);
+
+  const handleMove = useCallback((event: React.MouseEvent) => {
+    stopMenuEvent(event);
+    setMoveRequest({
+      sourceXBlockInfo: { id: blockId, displayName },
+      sourceParentXBlockInfo: {
+        id: unitId,
+        displayName: '',
+        category: 'vertical',
+        hasChildren: true,
+      },
+    });
+    openMoveModal();
+  }, [blockId, displayName, openMoveModal, unitId]);
+
+  const handleMoveModalClose = useCallback(() => {
+    closeMoveModal();
+    setMoveRequest(null);
+  }, [closeMoveModal]);
+
+  const handleDuplicate = useCallback(async (event: React.MouseEvent) => {
+    stopMenuEvent(event);
+    try {
+      await duplicateComponent(blockId);
+      onActionComplete();
+    } catch {
+      showToast(intl.formatMessage(messages.componentDuplicateError));
+    }
+  }, [blockId, duplicateComponent, onActionComplete, showToast, intl]);
+
+  const handleDeleteSubmit = useCallback(async () => {
+    try {
+      await deleteComponent(blockId);
+      closeDeleteModal();
+      onActionComplete();
+    } catch {
+      closeDeleteModal();
+      showToast(intl.formatMessage(messages.componentDeleteError));
+    }
+  }, [blockId, closeDeleteModal, deleteComponent, onActionComplete, showToast, intl]);
+
+  const {
+    canManageAccess, canMove, canCopy, canDuplicate, canDelete,
+  } = actions;
+  if (!canManageAccess && !canMove && !canCopy && !canDuplicate && !canDelete) {
+    return null;
+  }
+
+  const menuItemProps = { onMouseDown: stopMenuEvent };
+
+  return (
+    <>
+      <span
+        className="component-menu-wrapper flex-shrink-0"
+        role="presentation"
+        onClick={stopMenuEvent}
+        onMouseDown={stopMenuEvent}
+        onKeyDown={stopMenuEvent}
+      >
+        <Dropdown
+          id={`component-menu-${blockId}`}
+          data-testid="component-menu"
+          onToggle={(_isOpen, event) => event?.stopPropagation()}
+        >
+          <Dropdown.Toggle
+            id={`component-menu-toggle-${blockId}`}
+            as={IconButton}
+            src={MoreVert}
+            iconAs={Icon}
+            size="sm"
+            variant="primary"
+            alt={intl.formatMessage(messages.componentMenuAlt)}
+            data-testid="component-menu-toggle"
+            className="component-card-button-icon ml-1"
+            onMouseDown={stopMenuEvent}
+          />
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
+            {canManageAccess && (
+              <Dropdown.Item
+                {...menuItemProps}
+                onClick={handleManageAccess}
+                data-testid="component-menu-manage-access"
+              >
+                <FormattedMessage {...messages.menuManageAccess} />
+              </Dropdown.Item>
+            )}
+            {canMove && (
+              <Dropdown.Item
+                {...menuItemProps}
+                onClick={handleMove}
+                data-testid="component-menu-move"
+              >
+                <FormattedMessage {...moveModalMessages.moveModalSubmitButton} />
+              </Dropdown.Item>
+            )}
+            {canCopy && (
+              <Dropdown.Item
+                {...menuItemProps}
+                onClick={(event) => {
+                  stopMenuEvent(event);
+                  copyToClipboard(blockId);
+                }}
+                data-testid="component-menu-copy"
+              >
+                <FormattedMessage {...cardHeaderMessages.menuCopy} />
+              </Dropdown.Item>
+            )}
+            {canDuplicate && (
+              <Dropdown.Item
+                {...menuItemProps}
+                onClick={handleDuplicate}
+                data-testid="component-menu-duplicate"
+              >
+                <FormattedMessage {...cardHeaderMessages.menuDuplicate} />
+              </Dropdown.Item>
+            )}
+            {canDelete && (
+              <Dropdown.Item
+                {...menuItemProps}
+                onClick={(event) => {
+                  stopMenuEvent(event);
+                  openDeleteModal();
+                }}
+                data-testid="component-menu-delete"
+              >
+                <FormattedMessage {...cardHeaderMessages.menuDelete} />
+              </Dropdown.Item>
+            )}
+          </Dropdown.Menu>
+        </Dropdown>
+      </span>
+      {isConfigureModalOpen && configureItemData && (
+        <ConfigureModal
+          key={configureItemData.id}
+          isXBlockComponent
+          isOpen={isConfigureModalOpen}
+          onClose={handleConfigureClose}
+          onConfigureSubmit={handleConfigureSubmit}
+          currentItemData={configureItemData}
+          isSelfPaced={false}
+        />
+      )}
+      {isMoveModalOpen && courseId && (
+        <IframeProvider>
+          <MoveModal
+            isOpenModal={isMoveModalOpen}
+            openModal={openMoveModal}
+            closeModal={handleMoveModalClose}
+            courseId={courseId}
+            currentParentLocator={unitId}
+            moveRequest={moveRequest}
+            onMoveComplete={onActionComplete}
+          />
+        </IframeProvider>
+      )}
+      <DeleteModal
+        category="component"
+        isOpen={isDeleteModalOpen}
+        close={closeDeleteModal}
+        onDeleteSubmit={handleDeleteSubmit}
+      />
+    </>
+  );
+};
+
+export default ComponentMenu;

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -42,7 +42,8 @@
           }
         }
 
-        >a.component-card-button-icon {
+        >a.component-card-button-icon,
+        .component-menu-wrapper .component-card-button-icon {
           text-decoration: none;
           color: var(--pgn-color-primary-500);
 
@@ -52,6 +53,10 @@
             color: var(--pgn-color-white);
             background-color: var(--pgn-color-primary-500);
           }
+        }
+
+        .component-menu-wrapper {
+          flex-shrink: 0;
         }
       }
     }

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -34,6 +34,12 @@ jest.mock('./data/hooks', () => ({
     mutateAsync: mockCreateXBlock,
     isPending: false,
   }),
+  useDeleteUnitComponent: () => ({
+    mutateAsync: jest.fn(),
+  }),
+  useDuplicateUnitComponent: () => ({
+    mutateAsync: jest.fn(),
+  }),
 }));
 
 // Mock pasteBlock API call used by handlePasteComponent

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   useToggle, Icon, OverlayTrigger, Tooltip,
 } from '@openedx/paragon';
@@ -21,6 +21,7 @@ import { useWaffleFlags } from '@src/data/apiHooks';
 
 import CourseOutlineUnitCardExtraActionsSlot from '@src/plugin-slots/CourseOutlineUnitCardExtraActionsSlot';
 import { setCurrentItem, setCurrentSection, setCurrentSubsection } from '@src/course-outline/data/slice';
+import { getSectionsList } from '@src/course-outline/data/selectors';
 import { fetchCourseSectionQuery } from '@src/course-outline/data/thunk';
 import { setCourseItemOrderList, pasteBlock } from '@src/course-outline/data/api';
 import { RequestStatus, RequestStatusType } from '@src/data/constants';
@@ -42,8 +43,10 @@ import EditorPage from '@src/editors/EditorPage';
 import supportedEditors from '@src/editors/supportedEditors';
 import DraggableList, { SortableItem as GenericSortableItem } from '@src/generic/DraggableList';
 import { ToastContext } from '@src/generic/toast-context';
+import { deriveHasPartitionGroupComponents, EMPTY_UNIT_COMPONENT_ACTIONS, findSectionIdForUnit } from './data/api';
 import { useUnitHandler, useComponentTemplates } from './data/hooks';
 import AddComponentWidget from './AddComponentWidget';
+import ComponentMenu from './ComponentMenu';
 import messages from './messages';
 
 interface UnitCardProps {
@@ -91,6 +94,7 @@ const UnitCard = ({
   const currentRef = useRef(null);
   const dispatch = useDispatch();
   const intl = useIntl();
+  const sectionsList = useSelector(getSectionsList);
   const waffleFlags = useWaffleFlags();
   const [searchParams] = useSearchParams();
   const locatorId = searchParams.get('show');
@@ -179,6 +183,14 @@ const UnitCard = ({
     hasChanges,
   });
   const borderStyle = getItemStatusBorder(unitStatus);
+
+  const unitStatusData = useMemo(() => ({
+    ...unit,
+    hasPartitionGroupComponents: deriveHasPartitionGroupComponents(
+      unit,
+      unitData?.components,
+    ),
+  }), [unit, unitData?.components]);
 
   const handleClickMenuButton = () => {
     dispatch(setCurrentItem(unit));
@@ -292,6 +304,26 @@ const UnitCard = ({
       handleShowLegacyEditModal(blockId);
     }
   };
+
+  const handleComponentActionComplete = useCallback(async (targetUnitId?: string) => {
+    const sectionIds = new Set([section.id]);
+    if (targetUnitId && targetUnitId !== id) {
+      const targetSectionId = findSectionIdForUnit(sectionsList, targetUnitId);
+      if (targetSectionId) {
+        sectionIds.add(targetSectionId);
+      }
+    }
+
+    await dispatch(fetchCourseSectionQuery([...sectionIds]) as any);
+
+    const refetchPromises: Promise<unknown>[] = [refetchUnitData()];
+    if (targetUnitId && targetUnitId !== id) {
+      refetchPromises.push(
+        queryClient.refetchQueries({ queryKey: ['unitHandler', targetUnitId] }),
+      );
+    }
+    await Promise.all(refetchPromises);
+  }, [dispatch, section.id, sectionsList, queryClient, id, refetchUnitData]);
 
   const handleComponentReorder = useCallback(() => async (newOrder: any[]) => {
     if (!newOrder) {
@@ -476,7 +508,7 @@ const UnitCard = ({
             <XBlockStatus
               isSelfPaced={isSelfPaced}
               isCustomRelativeDatesActive={isCustomRelativeDatesActive}
-              blockData={unit}
+              blockData={unitStatusData}
             />
           </div>
 
@@ -513,13 +545,6 @@ const UnitCard = ({
                             id={component.blockId}
                             key={component.blockId}
                             buttonVariant="secondary"
-                            isClickable
-                            onClick={() => handleComponentClick(component.blockId)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                handleComponentClick(component.blockId);
-                              }
-                            }}
                             componentStyle={{
                               background: 'white',
                               borderRadius: '6px',
@@ -573,6 +598,16 @@ const UnitCard = ({
                                     </span>
                                   </a>
                                 </OverlayTrigger>
+                                <ComponentMenu
+                                  unitId={id}
+                                  blockId={component.blockId}
+                                  displayName={component.displayName}
+                                  blockType={component.blockType}
+                                  userPartitionInfo={component.userPartitionInfo}
+                                  userPartitions={component.userPartitions}
+                                  actions={component.actions ?? EMPTY_UNIT_COMPONENT_ACTIONS}
+                                  onActionComplete={handleComponentActionComplete}
+                                />
                               </>
                             )}
                           />

--- a/src/course-outline/unit-card/data/api.test.ts
+++ b/src/course-outline/unit-card/data/api.test.ts
@@ -1,15 +1,96 @@
 import { initializeMocks } from '@src/testUtils';
-import { getUnitHandler, getUnitHandlerApiUrl } from './api';
+import { getCourseVerticalChildrenApiUrl } from '@src/course-unit/data/api';
+import {
+  deriveHasPartitionGroupComponents,
+  getUnitHandler,
+} from './api';
 
-// Mock unit handler API response in snake_case (as returned by Django)
-const mockUnitHandlerResponse = {
-  unit_id: 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123',
+const unitId = 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123';
+
+// Mock container children API response in snake_case (as returned by Django)
+const mockContainerChildrenResponse = {
   display_name: 'Test Unit',
-  components: [
-    { block_id: 'block-v1:edX+DemoX+Demo+type@html+block@1', block_type: 'html', display_name: 'Text' },
-    { block_id: 'block-v1:edX+DemoX+Demo+type@video+block@2', block_type: 'video', display_name: 'Video' },
+  children: [
+    {
+      block_id: 'block-v1:edX+DemoX+Demo+type@html+block@1',
+      block_type: 'html',
+      name: 'Text',
+      actions: {
+        can_copy: true,
+        can_duplicate: true,
+        can_delete: true,
+        can_move: false,
+        can_manage_access: false,
+      },
+    },
+    {
+      block_id: 'block-v1:edX+DemoX+Demo+type@video+block@2',
+      block_type: 'video',
+      name: 'Video',
+    },
   ],
+  is_published: false,
+  can_paste_component: true,
+  upstream_ready_to_sync_children_info: [],
 };
+
+describe('deriveHasPartitionGroupComponents', () => {
+  it('returns true when a component has selected partition groups', () => {
+    const components = [{
+      blockId: 'block-1',
+      blockType: 'html',
+      displayName: 'Text',
+      userPartitionInfo: {
+        selectablePartitions: [{
+          id: 50,
+          name: 'Enrollment Track Groups',
+          scheme: 'enrollment_track',
+          groups: [{
+            id: 1,
+            name: 'Audit',
+            selected: true,
+            deleted: false,
+          }],
+        }],
+        selectedPartitionIndex: -1,
+        selectedGroupsLabel: '',
+      },
+      actions: {
+        canCopy: false, canDuplicate: false, canDelete: false, canMove: false, canManageAccess: false,
+      },
+    }];
+
+    expect(deriveHasPartitionGroupComponents({ hasPartitionGroupComponents: false }, components)).toBe(true);
+  });
+
+  it('returns false when no components have partition group access', () => {
+    const components = [{
+      blockId: 'block-1',
+      blockType: 'html',
+      displayName: 'Text',
+      userPartitionInfo: {
+        selectablePartitions: [{
+          id: 50,
+          name: 'Enrollment Track Groups',
+          scheme: 'enrollment_track',
+          groups: [{
+            id: 1,
+            name: 'Audit',
+            selected: false,
+            deleted: false,
+          }],
+        }],
+        selectedPartitionIndex: -1,
+        selectedGroupsLabel: '',
+      },
+      actions: {
+        canCopy: false, canDuplicate: false, canDelete: false, canMove: false, canManageAccess: false,
+      },
+    }];
+
+    expect(deriveHasPartitionGroupComponents({ hasPartitionGroupComponents: true }, components)).toBe(false);
+  });
+});
 
 describe('unit-card data/api', () => {
   let axiosMock: ReturnType<typeof initializeMocks>['axiosMock'];
@@ -18,38 +99,38 @@ describe('unit-card data/api', () => {
     ({ axiosMock } = initializeMocks());
   });
 
-  describe('getUnitHandlerApiUrl', () => {
+  describe('getCourseVerticalChildrenApiUrl', () => {
     it('builds the correct URL for the given unitId', () => {
-      const unitId = 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123';
-      const url = getUnitHandlerApiUrl(unitId);
-      // URL should end with the unit handler path + unitId
-      expect(url).toContain(`/api/contentstore/v1/unit_handler/${unitId}`);
+      const url = getCourseVerticalChildrenApiUrl(unitId);
+      expect(url).toContain(`/api/contentstore/v1/container/${unitId}/children`);
     });
   });
 
   describe('getUnitHandler', () => {
-    const unitId = 'block-v1:edX+DemoX+Demo+type@vertical+block@abc123';
-
     it('fetches unit data and returns camelCase response', async () => {
-      // Mock the GET request for unit handler
-      axiosMock.onGet(getUnitHandlerApiUrl(unitId)).reply(200, mockUnitHandlerResponse);
+      axiosMock.onGet(getCourseVerticalChildrenApiUrl(unitId)).reply(200, mockContainerChildrenResponse);
 
       const result = await getUnitHandler(unitId);
 
-      // Should have made exactly one GET request
       expect(axiosMock.history.get).toHaveLength(1);
-      expect(axiosMock.history.get[0].url).toEqual(getUnitHandlerApiUrl(unitId));
+      expect(axiosMock.history.get[0].url).toEqual(getCourseVerticalChildrenApiUrl(unitId));
 
-      // Response should be camelCased
-      expect(result.unitId).toBe(mockUnitHandlerResponse.unit_id);
-      expect(result.displayName).toBe(mockUnitHandlerResponse.display_name);
+      expect(result.unitId).toBe(unitId);
+      expect(result.displayName).toBe(mockContainerChildrenResponse.display_name);
       expect(result.components).toHaveLength(2);
       expect(result.components[0].blockType).toBe('html');
+      expect(result.components[0].displayName).toBe('Text');
+      expect(result.components[0].actions).toEqual({
+        canCopy: true,
+        canDuplicate: true,
+        canDelete: true,
+        canMove: false,
+        canManageAccess: false,
+      });
     });
 
     it('throws on network error', async () => {
-      // Simulate a network failure
-      axiosMock.onGet(getUnitHandlerApiUrl(unitId)).networkError();
+      axiosMock.onGet(getCourseVerticalChildrenApiUrl(unitId)).networkError();
 
       await expect(getUnitHandler(unitId)).rejects.toThrow();
     });

--- a/src/course-outline/unit-card/data/api.ts
+++ b/src/course-outline/unit-card/data/api.ts
@@ -1,13 +1,33 @@
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
+import type { UserPartitionInfoTypes, UserPartitionTypes } from '@src/data/types';
+import { getCourseContainerChildren } from '@src/course-unit/data/api';
+import type { XBlockActionsTypes } from '@src/course-unit/xblock-container-iframe/types';
+import { normalizeUserPartitionInfo } from '@src/course-unit/xblock-container-iframe/utils';
+
 const getStudioBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
-// Shape of a single component inside a unit
+export type UnitComponentActions = Pick<
+XBlockActionsTypes,
+'canCopy' | 'canDuplicate' | 'canDelete' | 'canMove' | 'canManageAccess'
+>;
+
+export const EMPTY_UNIT_COMPONENT_ACTIONS: UnitComponentActions = {
+  canCopy: false,
+  canDuplicate: false,
+  canDelete: false,
+  canMove: false,
+  canManageAccess: false,
+};
+
 export interface UnitComponent {
   blockId: string;
   blockType: string;
   displayName: string;
+  userPartitionInfo?: UserPartitionInfoTypes;
+  userPartitions?: UserPartitionTypes[];
+  actions: UnitComponentActions;
 }
 
 // Shape of one entry in the component_templates array returned by the API
@@ -35,27 +55,97 @@ export interface UnitHandlerData {
   components: UnitComponent[];
 }
 
-export const getUnitHandlerApiUrl = (unitId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/unit_handler/${unitId}`;
-
-/**
- * Get unit handler data (components list).
- * @param {string} unitId
- * @returns {Promise<UnitHandlerData>}
- */
-export async function getUnitHandler(unitId: string): Promise<UnitHandlerData> {
-  const { data } = await getAuthenticatedHttpClient().get(getUnitHandlerApiUrl(unitId));
-  return camelCaseObject(data) as UnitHandlerData;
+function componentHasPartitionGroupAccess(
+  component: Pick<UnitComponent, 'userPartitionInfo' | 'userPartitions'>,
+): boolean {
+  const partitions = component.userPartitionInfo?.selectablePartitions
+    ?? component.userPartitions
+    ?? [];
+  return partitions.some(
+    (partition) => partition.groups?.some((group) => group.selected),
+  );
 }
 
-// Reuse the existing container_handler endpoint that already serves component_templates.
-const getContainerHandlerApiUrl = (unitId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/container_handler/${unitId}`;
+export function deriveHasPartitionGroupComponents(
+  unit: {
+    hasPartitionGroupComponents?: boolean;
+    userPartitionInfo?: UserPartitionInfoTypes;
+  },
+  components?: UnitComponent[],
+): boolean {
+  const selectedPartitionIndex = unit.userPartitionInfo?.selectedPartitionIndex ?? -1;
+  const unitHasDirectPartitionAccess = selectedPartitionIndex !== -1
+    && !Number.isNaN(selectedPartitionIndex);
+
+  if (components?.length) {
+    if (unitHasDirectPartitionAccess) {
+      return unit.hasPartitionGroupComponents ?? false;
+    }
+    return components.some(componentHasPartitionGroupAccess);
+  }
+
+  return unit.hasPartitionGroupComponents ?? false;
+}
+
+export function findSectionIdForUnit(
+  sectionsList: Array<{
+    id: string;
+    childInfo?: { children?: Array<{ childInfo?: { children?: Array<{ id: string }> } }> };
+  }>,
+  unitId: string,
+): string | undefined {
+  return sectionsList.find((section) => (
+    section.childInfo?.children?.some((subsection) => (
+      subsection.childInfo?.children?.some((unit) => unit.id === unitId)
+    ))
+  ))?.id;
+}
+
+function mapContainerChildToUnitComponent(child: {
+  blockId: string;
+  blockType: string;
+  name: string;
+  userPartitionInfo?: UserPartitionInfoTypes;
+  userPartitions?: UserPartitionTypes[];
+  actions?: Partial<UnitComponentActions>;
+}): UnitComponent {
+  return {
+    blockId: child.blockId,
+    blockType: child.blockType,
+    displayName: child.name,
+    userPartitionInfo: normalizeUserPartitionInfo(child),
+    userPartitions: child.userPartitions,
+    actions: {
+      canCopy: child.actions?.canCopy ?? false,
+      canDuplicate: child.actions?.canDuplicate ?? false,
+      canDelete: child.actions?.canDelete ?? false,
+      canMove: child.actions?.canMove ?? false,
+      canManageAccess: child.actions?.canManageAccess ?? false,
+    },
+  };
+}
+
+/**
+ * Get unit components and their available actions via the container children API
+ * (same source as the Unit page component menus).
+ */
+export async function getUnitHandler(unitId: string): Promise<UnitHandlerData> {
+  const containerData = await getCourseContainerChildren(unitId);
+  return {
+    unitId,
+    displayName: containerData.displayName,
+    components: containerData.children.map(mapContainerChildToUnitComponent),
+  };
+}
+
+const getContainerHandlerApiUrl = (unitId: string) => (
+  `${getStudioBaseUrl()}/api/contentstore/v1/container_handler/${unitId}`
+);
 
 /**
  * Fetch component templates for a unit by calling the existing container_handler API.
  * Templates are course-level (identical for all units in a course), so callers
  * should cache the result per courseId rather than per unit.
- * @param {string} unitId – any unit in the course
- * @returns {Promise<ComponentTemplate[]>}
  */
 export async function getComponentTemplates(unitId: string): Promise<ComponentTemplate[]> {
   const { data } = await getAuthenticatedHttpClient().get(getContainerHandlerApiUrl(unitId));

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -1,11 +1,16 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { camelCaseObject } from '@edx/frontend-platform';
-import { createCourseXblock } from '@src/course-unit/data/api';
+import {
+  createCourseXblock,
+  deleteUnitItem,
+  duplicateUnitItem,
+} from '@src/course-unit/data/api';
 import { getUnitHandler, getComponentTemplates } from './api';
 
-// Hook to fetch unit data (components list) when expanded
+const unitHandlerQueryKey = (unitId: string) => ['unitHandler', unitId] as const;
+
 export const useUnitHandler = (unitId: string, enabled: boolean = false) => useQuery({
-  queryKey: ['unitHandler', unitId],
+  queryKey: unitHandlerQueryKey(unitId),
   queryFn: () => getUnitHandler(unitId),
   enabled: enabled && !!unitId,
 });
@@ -45,8 +50,28 @@ export const useCreateXBlockInUnit = (unitId: string) => {
       return camelCaseObject(data) as { locator: string; courseKey: string };
     },
     onSuccess: () => {
-      // Refetch the unit handler data so the new component appears
-      queryClient.invalidateQueries({ queryKey: ['unitHandler', unitId] });
+      queryClient.invalidateQueries({ queryKey: unitHandlerQueryKey(unitId) });
     },
   });
 };
+
+const useUnitComponentMutation = <T>(
+  unitId: string,
+  mutationFn: (blockId: string) => Promise<T>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: unitHandlerQueryKey(unitId) });
+    },
+  });
+};
+
+export const useDeleteUnitComponent = (unitId: string) => (
+  useUnitComponentMutation(unitId, deleteUnitItem)
+);
+
+export const useDuplicateUnitComponent = (unitId: string) => (
+  useUnitComponentMutation(unitId, (blockId) => duplicateUnitItem(unitId, blockId))
+);

--- a/src/course-outline/unit-card/messages.js
+++ b/src/course-outline/unit-card/messages.js
@@ -76,6 +76,26 @@ const messages = defineMessages({
     defaultMessage: 'Select',
     description: 'Submit button in the template selection modal',
   },
+  componentMenuAlt: {
+    id: 'course-authoring.course-outline.unit.component-menu-alt',
+    defaultMessage: 'Component actions menu',
+    description: 'Alt/title text for the component menu button on the course outline',
+  },
+  menuManageAccess: {
+    id: 'course-authoring.course-outline.unit.component-menu-manage-access',
+    defaultMessage: 'Manage Access',
+    description: 'Menu item for managing component access from the course outline',
+  },
+  componentDuplicateError: {
+    id: 'course-authoring.course-outline.unit.component-duplicate-error',
+    defaultMessage: 'Failed to duplicate component. Please try again.',
+    description: 'Error message shown when duplicating a component from the outline fails',
+  },
+  componentDeleteError: {
+    id: 'course-authoring.course-outline.unit.component-delete-error',
+    defaultMessage: 'Failed to delete component. Please try again.',
+    description: 'Error message shown when deleting a component from the outline fails',
+  },
 });
 
 export default messages;

--- a/src/course-unit/move-modal/hooks.tsx
+++ b/src/course-unit/move-modal/hooks.tsx
@@ -23,9 +23,16 @@ import {
 
 // eslint-disable-next-line import/prefer-default-export
 export const useMoveModal = ({
-  isOpenModal, closeModal, openModal, courseId,
+  isOpenModal,
+  closeModal,
+  openModal,
+  courseId,
+  currentParentLocator: currentParentLocatorProp,
+  moveRequest,
+  onMoveComplete,
 }: IUseMoveModalParams): IUseMoveModalReturn => {
   const { blockId } = useParams<{ blockId: string }>();
+  const currentParentLocator = currentParentLocatorProp ?? blockId;
   const intl = useIntl();
   const dispatch = useDispatch();
   const { sendMessageToIframe } = useIframe();
@@ -182,15 +189,30 @@ export const useMoveModal = ({
       sourceLocator: state.sourceXBlockInfo.current.id,
       targetParentLocator: lastAncestor.id,
       title: state.sourceXBlockInfo.current.displayName,
-      currentParentLocator: blockId,
+      currentParentLocator,
       isMoving: true,
       callbackFn: (sourceLocator: string) => {
         sendMessageToIframe(messageTypes.completeXBlockMoving, { locator: sourceLocator });
         closeModal();
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        onMoveComplete?.(lastAncestor.id);
+        if (!onMoveComplete) {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
       },
     }));
-  }, [state, dispatch, blockId, closeModal]);
+  }, [state, dispatch, currentParentLocator, closeModal, sendMessageToIframe, onMoveComplete]);
+
+  useEffect(() => {
+    if (isOpenModal && moveRequest) {
+      setState((prevState) => ({
+        ...prevState,
+        sourceXBlockInfo: {
+          current: moveRequest.sourceXBlockInfo,
+          parent: moveRequest.sourceParentXBlockInfo,
+        },
+      }));
+    }
+  }, [isOpenModal, moveRequest]);
 
   useEffect(() => {
     if (isOpenModal && !Object.keys(courseOutlineInfo).length) {

--- a/src/course-unit/move-modal/index.tsx
+++ b/src/course-unit/move-modal/index.tsx
@@ -18,7 +18,13 @@ import { EmptyMessage, ModalLoader, CategoryIndicator } from './components';
 import messages from './messages';
 
 const MoveModal: FC<IUseMoveModalParams> = ({
-  isOpenModal, closeModal, openModal, courseId,
+  isOpenModal,
+  closeModal,
+  openModal,
+  courseId,
+  currentParentLocator,
+  moveRequest,
+  onMoveComplete,
 }) => {
   const intl = useIntl();
 
@@ -38,7 +44,13 @@ const MoveModal: FC<IUseMoveModalParams> = ({
     handleCLoseModal,
     handleMoveXBlock,
   } = useMoveModal({
-    isOpenModal, closeModal, openModal, courseId,
+    isOpenModal,
+    closeModal,
+    openModal,
+    courseId,
+    currentParentLocator,
+    moveRequest,
+    onMoveComplete,
   });
 
   const renderBreadcrumbs = useCallback(() => (

--- a/src/course-unit/move-modal/interfaces.ts
+++ b/src/course-unit/move-modal/interfaces.ts
@@ -8,11 +8,19 @@ export interface IXBlockInfo {
   hasChildren?: boolean;
 }
 
+export interface IMoveRequestPayload {
+  sourceXBlockInfo: IXBlockInfo;
+  sourceParentXBlockInfo: IXBlockInfo;
+}
+
 export interface IUseMoveModalParams {
   isOpenModal: boolean;
   closeModal: () => void;
   openModal: () => void;
   courseId: string;
+  currentParentLocator?: string;
+  moveRequest?: IMoveRequestPayload | null;
+  onMoveComplete?: (targetUnitId: string) => void;
 }
 
 export interface IUseMoveModalReturn {

--- a/src/course-unit/xblock-container-iframe/utils.ts
+++ b/src/course-unit/xblock-container-iframe/utils.ts
@@ -1,7 +1,42 @@
 import { getConfig } from '@edx/frontend-platform';
 
+import { UserPartitionInfoTypes, UserPartitionTypes } from '@src/data/types';
 import { COURSE_BLOCK_NAMES } from '../../constants';
 import { FormattedAccessManagedXBlockDataTypes, XBlockTypes } from './types';
+
+const emptyUserPartitionInfo = (): UserPartitionInfoTypes => ({
+  selectablePartitions: [],
+  selectedPartitionIndex: -1,
+  selectedGroupsLabel: '',
+});
+
+export const normalizeUserPartitionInfo = (xblock: {
+  userPartitionInfo?: UserPartitionInfoTypes;
+  userPartitions?: UserPartitionTypes[];
+}): UserPartitionInfoTypes => {
+  const partitionInfo = xblock.userPartitionInfo;
+  if (partitionInfo?.selectablePartitions?.length) {
+    return partitionInfo;
+  }
+
+  const userPartitions = xblock.userPartitions ?? [];
+  if (!userPartitions.length) {
+    return partitionInfo ?? emptyUserPartitionInfo();
+  }
+
+  const selectablePartitions = userPartitions.filter((partition) => {
+    if (partition.scheme === 'enrollment_track') {
+      return partition.groups.length > 1 || partition.groups.some((group) => group.selected);
+    }
+    return true;
+  });
+
+  return {
+    selectablePartitions: selectablePartitions.length ? selectablePartitions : userPartitions,
+    selectedPartitionIndex: partitionInfo?.selectedPartitionIndex ?? -1,
+    selectedGroupsLabel: partitionInfo?.selectedGroupsLabel ?? '',
+  };
+};
 
 /**
  * Formats the XBlock data into a standardized structure for access management.
@@ -17,7 +52,7 @@ export const formatAccessManagedXBlockData = (
 ): FormattedAccessManagedXBlockDataTypes => ({
   category: COURSE_BLOCK_NAMES.component.id,
   displayName: xblock.name,
-  userPartitionInfo: xblock.userPartitionInfo,
+  userPartitionInfo: normalizeUserPartitionInfo(xblock),
   showCorrectness: 'always',
   blockType: xblock.blockType,
   id: usageId,


### PR DESCRIPTION
- Added ComponentMenu component to manage actions (copy, duplicate, delete) for course outline units.
- Integrated hooks for delete and duplicate functionalities.
- Created tests for ComponentMenu to ensure proper rendering and action handling.
- Updated styles to accommodate the new component in the unit card layout.
- Enhanced messages for internationalization related to component actions.

---

JIRA Ticket : [TNL2-618](https://2u-internal.atlassian.net/browse/TNL2-618)

## Summary
Adds a per-component actions dropdown (ComponentMenu) to the expanded UnitCard in the Course Outline, bringing component-level actions (copy, duplicate, delete, move, manage access) to the outline view — consistent with what's already available on the Unit page.

## Testing Instructions
- Start Studio locally (make lms / make cms, port 18010).
- Open a course in the Course Outline page.
- Expand a unit that has XBlock components.
- Verify the three-dot / actions menu appears per component row.
- Test each action:
     * Copy - component appears in clipboard.
     * Duplicate - component is duplicated inline.
     * Delete - confirmation dialog shown; component removed on confirm.
     * Move - MoveModal opens with correct source context; post-move refresh triggers.
     * Manage Access - access dialog opens with correct partition group data.

- Confirm no regressions on the Unit page component actions.
- Run unit tests: npm test src/course-outline/unit-card/

## Screen recording:
https://github.com/user-attachments/assets/0d1bc9b6-6a0a-482b-a5ae-e386295f86af




## Checklist
- [x] Tests added/updated
- [x] i18n strings added
- [x] No hardcoded strings