### PR TITLE
feat(course-outline): add inline rename functionality for components in UnitCard

### DIFF
--- a/src/course-outline/unit-card/AddComponentWidget.tsx
+++ b/src/course-outline/unit-card/AddComponentWidget.tsx
@@ -51,7 +51,7 @@ const AddComponentWidget = ({
 }: AddComponentWidgetProps) => {
   const intl = useIntl();
   const { showToast } = useContext(ToastContext);
-  const { mutateAsync: createXBlock, isPending } = useCreateXBlockInUnit(unitId);
+  const { mutateAsync: createXBlock, isPending } = useCreateXBlockInUnit();
 
   // State for template selection modal – shown when a component type has multiple templates
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/course-outline/unit-card/ComponentMenu.test.tsx
+++ b/src/course-outline/unit-card/ComponentMenu.test.tsx
@@ -1,6 +1,7 @@
 import {
   act, fireEvent, initializeMocks, render, screen, waitFor,
 } from '@src/testUtils';
+import { useState } from 'react';
 
 import cardHeaderMessages from '@src/course-outline/card-header/messages';
 import ComponentMenu from './ComponentMenu';
@@ -25,22 +26,33 @@ jest.mock('./data/hooks', () => ({
   }),
 }));
 
+const ComponentMenuHarness = (props: Partial<React.ComponentProps<typeof ComponentMenu>>) => {
+  const [openBlockId, setOpenBlockId] = useState<string | null>(null);
+  const blockId = props.blockId ?? 'block-v1:test+type@html+block@1';
+
+  return (
+    <ComponentMenu
+      unitId="block-v1:test+type@vertical+block@unit1"
+      blockId={blockId}
+      displayName="Test Component"
+      blockType="html"
+      actions={{
+        canCopy: true,
+        canDuplicate: true,
+        canDelete: true,
+        canMove: false,
+        canManageAccess: false,
+      }}
+      onActionComplete={mockOnActionComplete}
+      isMenuOpen={openBlockId === blockId}
+      onMenuToggle={setOpenBlockId}
+      {...props}
+    />
+  );
+};
+
 const renderComponentMenu = (props?: Partial<React.ComponentProps<typeof ComponentMenu>>) => render(
-  <ComponentMenu
-    unitId="block-v1:test+type@vertical+block@unit1"
-    blockId="block-v1:test+type@html+block@1"
-    displayName="Test Component"
-    blockType="html"
-    actions={{
-      canCopy: true,
-      canDuplicate: true,
-      canDelete: true,
-      canMove: false,
-      canManageAccess: false,
-    }}
-    onActionComplete={mockOnActionComplete}
-    {...props}
-  />,
+  <ComponentMenuHarness {...props} />,
 );
 
 describe('<ComponentMenu />', () => {
@@ -108,16 +120,62 @@ describe('<ComponentMenu />', () => {
   });
 
   it('does not render when no actions are available', () => {
-    renderComponentMenu({
-      actions: {
-        canCopy: false,
-        canDuplicate: false,
-        canDelete: false,
-        canMove: false,
-        canManageAccess: false,
-      },
-    });
+    render(
+      <ComponentMenuHarness
+        actions={{
+          canCopy: false,
+          canDuplicate: false,
+          canDelete: false,
+          canMove: false,
+          canManageAccess: false,
+        }}
+      />,
+    );
 
     expect(screen.queryByTestId('component-menu')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu when another component menu is opened', async () => {
+    const SharedMenus = () => {
+      const [openBlockId, setOpenBlockId] = useState<string | null>(null);
+      const sharedProps = {
+        unitId: 'block-v1:test+type@vertical+block@unit1',
+        displayName: 'Test Component',
+        blockType: 'html',
+        actions: {
+          canCopy: true,
+          canDuplicate: true,
+          canDelete: true,
+          canMove: false,
+          canManageAccess: true,
+        },
+        onActionComplete: mockOnActionComplete,
+        onMenuToggle: setOpenBlockId,
+      };
+
+      return (
+        <>
+          <ComponentMenu
+            {...sharedProps}
+            blockId="block-v1:test+type@html+block@1"
+            isMenuOpen={openBlockId === 'block-v1:test+type@html+block@1'}
+          />
+          <ComponentMenu
+            {...sharedProps}
+            blockId="block-v1:test+type@html+block@2"
+            isMenuOpen={openBlockId === 'block-v1:test+type@html+block@2'}
+          />
+        </>
+      );
+    };
+
+    render(<SharedMenus />);
+
+    const [firstToggle, secondToggle] = screen.getAllByTestId('component-menu-toggle');
+    await act(async () => fireEvent.click(firstToggle));
+    expect(screen.getByTestId('component-menu-manage-access')).toBeInTheDocument();
+
+    await act(async () => fireEvent.click(secondToggle));
+    expect(screen.getAllByTestId('component-menu-manage-access')).toHaveLength(1);
   });
 });

--- a/src/course-outline/unit-card/ComponentMenu.tsx
+++ b/src/course-outline/unit-card/ComponentMenu.tsx
@@ -69,7 +69,7 @@ const ComponentMenu = ({
   const [isMoveModalOpen, openMoveModal, closeMoveModal] = useToggle(false);
   const [moveRequest, setMoveRequest] = useState<IMoveRequestPayload | null>(null);
   const [configureItemData, setConfigureItemData] = useState<FormattedAccessManagedXBlockDataTypes | null>(null);
-  const { mutateAsync: deleteComponent } = useDeleteUnitComponent(unitId);
+  const { mutateAsync: deleteComponent } = useDeleteUnitComponent();
   const { mutateAsync: duplicateComponent } = useDuplicateUnitComponent(unitId);
 
   const handleManageAccess = useCallback((event: React.MouseEvent) => {

--- a/src/course-outline/unit-card/ComponentMenu.tsx
+++ b/src/course-outline/unit-card/ComponentMenu.tsx
@@ -39,6 +39,8 @@ interface ComponentMenuProps {
   userPartitions?: XBlockTypes['userPartitions'];
   actions: UnitComponentActions;
   onActionComplete: (targetUnitId?: string) => void;
+  isMenuOpen: boolean;
+  onMenuToggle: (blockId: string | null) => void;
 }
 
 const stopMenuEvent = (event: React.SyntheticEvent) => {
@@ -54,6 +56,8 @@ const ComponentMenu = ({
   userPartitions,
   actions,
   onActionComplete,
+  isMenuOpen,
+  onMenuToggle,
 }: ComponentMenuProps) => {
   const intl = useIntl();
   const dispatch = useDispatch();
@@ -171,8 +175,13 @@ const ComponentMenu = ({
       >
         <Dropdown
           id={`component-menu-${blockId}`}
+          key={`${blockId}-${isMenuOpen}`}
           data-testid="component-menu"
-          onToggle={(_isOpen, event) => event?.stopPropagation()}
+          show={isMenuOpen}
+          onToggle={(isOpen, event) => {
+            event?.stopPropagation();
+            onMenuToggle(isOpen ? blockId : null);
+          }}
         >
           <Dropdown.Toggle
             id={`component-menu-toggle-${blockId}`}

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -25,15 +25,27 @@
         display: flex;
         align-items: center;
 
-        >.flex-grow-1 {
+        .item-card-header,
+        .form-group {
           min-width: 0;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          max-width: 80%;
         }
 
-        >a.flex-grow-1 {
+        .component-title-group {
+          flex: 0 1 auto;
+          align-items: center;
+
+          .item-card-header__title-btn {
+            flex: 0 1 auto;
+            min-width: 0;
+            margin-right: .5rem;
+          }
+
+          .item-card-button-icon {
+            flex-shrink: 0;
+          }
+        }
+
+        >a.item-card-header__title-btn {
           color: inherit;
           text-decoration: none;
 
@@ -42,21 +54,71 @@
           }
         }
 
-        >a.component-card-button-icon,
-        .component-menu-wrapper .component-card-button-icon {
-          text-decoration: none;
-          color: var(--pgn-color-primary-500);
+        .item-card-header__title-btn .truncate-1-line {
+          min-width: 0;
+          display: block;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
 
-          &:hover,
+        .item-card-button-icon {
+          opacity: 0;
+          transition: opacity .3s linear;
+
           &:focus {
-            text-decoration: none;
-            color: var(--pgn-color-white);
-            background-color: var(--pgn-color-primary-500);
+            opacity: 1;
           }
+        }
+
+        .component-rename-button {
+          margin-right: .5rem;
+        }
+
+        &:hover .item-card-button-icon {
+          opacity: 1;
+        }
+
+        .component-header-actions {
+          flex-shrink: 0;
+          opacity: 1;
+          margin-left: .25rem;
+          align-items: center;
+        }
+
+        .component-edit-button,
+        .component-menu-wrapper,
+        .btn-icon.btn-icon-md {
+          align-self: center;
+        }
+
+        .component-edit-button {
+          width: 4.125rem;
+          height: 2.25rem;
+          white-space: nowrap;
+        }
+
+        .btn-icon.btn-icon-md {
+          width: 2.5rem;
+          height: 2.5rem;
         }
 
         .component-menu-wrapper {
           flex-shrink: 0;
+          opacity: 1;
+
+          .component-card-button-icon {
+            opacity: 1;
+            text-decoration: none;
+            color: var(--pgn-color-primary-500);
+
+            &:hover,
+            &:focus {
+              text-decoration: none;
+              color: var(--pgn-color-white);
+              background-color: var(--pgn-color-primary-500);
+            }
+          }
         }
       }
     }
@@ -95,6 +157,10 @@
 
         .component-card-button-icon:hover {
           background-color: var(--pgn-color-icon-button-bg-primary-hover);
+        }
+
+        .component-edit-button {
+          white-space: nowrap;
         }
       }
     }

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -5,6 +5,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 
 import { XBlock } from '@src/data/types';
+import headerNavigationsMessages from '@src/course-unit/header-navigations/messages';
 import UnitCard from './UnitCard';
 import cardMessages from '../card-header/messages';
 import componentMessages from './messages';
@@ -16,6 +17,7 @@ const mockUseComponentTemplates = jest.fn();
 const mockCreateXBlock = jest.fn();
 const mockPasteBlock = jest.fn();
 const mockCopyToClipboard = jest.fn();
+const mockRenameComponent = jest.fn();
 const mockShowPasteXBlock = { current: false };
 
 jest.mock('@src/course-unit/data/apiHooks', () => ({
@@ -39,6 +41,10 @@ jest.mock('./data/hooks', () => ({
   }),
   useDuplicateUnitComponent: () => ({
     mutateAsync: jest.fn(),
+  }),
+  useRenameUnitComponent: () => ({
+    mutateAsync: mockRenameComponent,
+    isPending: false,
   }),
 }));
 
@@ -171,6 +177,8 @@ describe('<UnitCard />', () => {
     mockUseComponentTemplates.mockReturnValue({ data: undefined });
     mockPasteBlock.mockReset();
     mockCreateXBlock.mockReset();
+    mockRenameComponent.mockReset();
+    mockRenameComponent.mockResolvedValue(undefined);
     mockShowPasteXBlock.current = false;
   });
 
@@ -363,6 +371,7 @@ describe('<UnitCard />', () => {
       const editButton = await screen.findByTestId('component-edit-button');
       expect(editButton.tagName).toBe('A');
       expect(editButton).toHaveAttribute('href', `/course/5/editor/html/${htmlComponent.blockId}`);
+      expect(editButton).toHaveTextContent(headerNavigationsMessages.editButton.defaultMessage);
     });
 
     it('renders edit button with legacy Studio URL for non-MFE types', async () => {
@@ -397,6 +406,29 @@ describe('<UnitCard />', () => {
 
       const prevented = !editButton.dispatchEvent(clickEvent);
       expect(prevented).toBe(false);
+    });
+
+    it('shows inline rename field after clicking the rename button', async () => {
+      await setupExpandedView([htmlComponent]);
+
+      const renameButton = await screen.findByTestId('component-rename-button');
+      fireEvent.click(renameButton);
+
+      const renameField = await screen.findByTestId('component-rename-field');
+      expect(renameField).toBeInTheDocument();
+      expect(renameField).toHaveValue('HTML Component');
+
+      fireEvent.change(renameField, { target: { value: 'Renamed Component' } });
+      expect(renameField).toHaveValue('Renamed Component');
+
+      fireEvent.blur(renameField);
+
+      await waitFor(() => {
+        expect(mockRenameComponent).toHaveBeenCalledWith({
+          blockId: htmlComponent.blockId,
+          displayName: 'Renamed Component',
+        });
+      });
     });
   });
 

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  useToggle, Icon, OverlayTrigger, Tooltip,
+  useToggle, Icon, Form, IconButtonWithTooltip, Button, OverlayTrigger, Tooltip, Stack,
 } from '@openedx/paragon';
 import { EditOutline as EditIcon } from '@openedx/paragon/icons';
 import { isEmpty } from 'lodash';
@@ -17,6 +17,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 
+import { NOTIFICATION_MESSAGES } from '@src/constants';
+import {
+  hideProcessingNotification,
+  showProcessingNotification,
+} from '@src/generic/processing-notification/data/slice';
 import { useWaffleFlags } from '@src/data/apiHooks';
 
 import CourseOutlineUnitCardExtraActionsSlot from '@src/plugin-slots/CourseOutlineUnitCardExtraActionsSlot';
@@ -26,6 +31,7 @@ import { fetchCourseSectionQuery } from '@src/course-outline/data/thunk';
 import { setCourseItemOrderList, pasteBlock } from '@src/course-outline/data/api';
 import { RequestStatus, RequestStatusType } from '@src/data/constants';
 import CardHeader from '@src/course-outline/card-header/CardHeader';
+import cardHeaderMessages from '@src/course-outline/card-header/messages';
 import SortableItem from '@src/course-outline/drag-helper/SortableItem';
 import TitleButton from '@src/course-outline/card-header/TitleButton';
 import TitleLink from '@src/course-outline/card-header/TitleLink';
@@ -44,7 +50,7 @@ import supportedEditors from '@src/editors/supportedEditors';
 import DraggableList, { SortableItem as GenericSortableItem } from '@src/generic/DraggableList';
 import { ToastContext } from '@src/generic/toast-context';
 import { deriveHasPartitionGroupComponents, EMPTY_UNIT_COMPONENT_ACTIONS, findSectionIdForUnit } from './data/api';
-import { useUnitHandler, useComponentTemplates } from './data/hooks';
+import { useUnitHandler, useComponentTemplates, useRenameUnitComponent } from './data/hooks';
 import AddComponentWidget from './AddComponentWidget';
 import ComponentMenu from './ComponentMenu';
 import messages from './messages';
@@ -108,6 +114,9 @@ const UnitCard = ({
   const [editBlockType, setEditBlockType] = useState<string>('');
   const [orderedComponents, setOrderedComponents] = useState<any[]>([]);
   const [dragComponentId, setDragComponentId] = useState<string | null>(null);
+  const [renamingBlockId, setRenamingBlockId] = useState<string | null>(null);
+  const [renameTitleValue, setRenameTitleValue] = useState('');
+  const [openComponentMenuBlockId, setOpenComponentMenuBlockId] = useState<string | null>(null);
   const previousComponentsOrder = useRef<any[]>([]);
   const namePrefix = 'unit';
 
@@ -129,6 +138,8 @@ const UnitCard = ({
     discussionEnabled,
     upstreamInfo,
   } = unit;
+
+  const { mutateAsync: renameComponent, isPending: isRenamePending } = useRenameUnitComponent(id);
 
   // Fetch unit components when expanded (only if flag is enabled)
   const {
@@ -325,6 +336,47 @@ const UnitCard = ({
     await Promise.all(refetchPromises);
   }, [dispatch, section.id, sectionsList, queryClient, id, refetchUnitData]);
 
+  const handleRenameStart = useCallback((blockId: string, currentName: string) => {
+    setRenamingBlockId(blockId);
+    setRenameTitleValue(currentName);
+  }, []);
+
+  const handleRenameCancel = useCallback((currentName: string) => {
+    setRenamingBlockId(null);
+    setRenameTitleValue(currentName);
+  }, []);
+
+  const handleRenameSubmit = useCallback(async (blockId: string, currentName: string) => {
+    const trimmedName = renameTitleValue.trim();
+
+    if (!trimmedName || trimmedName === currentName) {
+      setRenamingBlockId(null);
+      setRenameTitleValue('');
+      return;
+    }
+
+    try {
+      dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
+      await renameComponent({ blockId, displayName: trimmedName });
+      await handleComponentActionComplete();
+      setRenamingBlockId(null);
+      setRenameTitleValue('');
+    } catch {
+      setRenamingBlockId(null);
+      setRenameTitleValue('');
+      showToast(intl.formatMessage(messages.componentRenameError));
+    } finally {
+      dispatch(hideProcessingNotification());
+    }
+  }, [
+    renameTitleValue,
+    renameComponent,
+    handleComponentActionComplete,
+    dispatch,
+    showToast,
+    intl,
+  ]);
+
   const handleComponentReorder = useCallback(() => async (newOrder: any[]) => {
     if (!newOrder) {
       return;
@@ -386,7 +438,7 @@ const UnitCard = ({
     if (savingStatus === RequestStatus.SUCCESSFUL) {
       closeForm();
     }
-  }, [savingStatus]);
+  }, [savingStatus, closeForm]);
 
   useEffect(() => {
     if (unitData?.components) {
@@ -557,57 +609,128 @@ const UnitCard = ({
                             }}
                             actions={(
                               <>
-                                <Icon src={ComponentIcon} className="mr-2 text-dark" />
-                                <a
-                                  href={`${getTitleLink(id)}#${component.blockId}`}
-                                  className="flex-grow-1"
-                                  data-testid="component-name-link"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    if (!e.metaKey && !e.ctrlKey) {
-                                      e.preventDefault();
-                                      handleComponentClick(component.blockId);
-                                    }
-                                  }}
-                                >
-                                  {component.displayName}
-                                </a>
-                                <OverlayTrigger
-                                  placement="top"
-                                  overlay={(
-                                    <Tooltip id={`edit-tooltip-${component.blockId}`}>
-                                      {intl.formatMessage(messages.editComponent)}
-                                    </Tooltip>
-                                  )}
-                                >
-                                  <a
-                                    href={getComponentEditorUrl(component.blockType, component.blockId)}
-                                    className="component-card-button-icon btn btn-icon btn-icon-primary btn-icon-md"
-                                    data-testid="component-edit-button"
-                                    aria-label={intl.formatMessage(messages.editComponent)}
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      if (!e.metaKey && !e.ctrlKey) {
-                                        e.preventDefault();
-                                        handleComponentEdit(e, component.blockType, component.blockId);
-                                      }
-                                    }}
+                                <Icon src={ComponentIcon} className="mr-2 text-dark flex-shrink-0" />
+                                {renamingBlockId === component.blockId ? (
+                                  <Form.Group
+                                    className="m-0 flex-grow-1 min-width-0"
+                                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                                    onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
                                   >
-                                    <span className="btn-icon_btn-icon-primary_icon">
-                                      <Icon src={EditIcon} />
-                                    </span>
-                                  </a>
-                                </OverlayTrigger>
-                                <ComponentMenu
-                                  unitId={id}
-                                  blockId={component.blockId}
-                                  displayName={component.displayName}
-                                  blockType={component.blockType}
-                                  userPartitionInfo={component.userPartitionInfo}
-                                  userPartitions={component.userPartitions}
-                                  actions={component.actions ?? EMPTY_UNIT_COMPONENT_ACTIONS}
-                                  onActionComplete={handleComponentActionComplete}
-                                />
+                                    <Form.Control
+                                      autoFocus
+                                      data-testid="component-rename-field"
+                                      value={renameTitleValue}
+                                      name="displayName"
+                                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                        setRenameTitleValue(e.target.value);
+                                      }}
+                                      aria-label={intl.formatMessage(cardHeaderMessages.editFieldAriaLabel)}
+                                      onBlur={() => handleRenameSubmit(
+                                        component.blockId,
+                                        component.displayName,
+                                      )}
+                                      onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                                        if (e.key === 'Enter') {
+                                          handleRenameSubmit(
+                                            component.blockId,
+                                            component.displayName,
+                                          );
+                                        } else if (e.key === 'Escape') {
+                                          handleRenameCancel(component.displayName);
+                                        }
+                                      }}
+                                      disabled={isRenamePending}
+                                    />
+                                  </Form.Group>
+                                ) : (
+                                  <Stack
+                                    direction="horizontal"
+                                    gap={0}
+                                    className="item-card-header component-title-group flex-grow-1 min-width-0"
+                                    role="presentation"
+                                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                                    onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                                  >
+                                    <a
+                                      href={`${getTitleLink(id)}#${component.blockId}`}
+                                      className="item-card-header__title-btn"
+                                      data-testid="component-name-link"
+                                      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                                        e.stopPropagation();
+                                        if (!e.metaKey && !e.ctrlKey) {
+                                          e.preventDefault();
+                                          handleComponentClick(component.blockId);
+                                        }
+                                      }}
+                                      onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                                    >
+                                      <span className="truncate-1-line mb-0">
+                                        {component.displayName}
+                                      </span>
+                                    </a>
+                                    <IconButtonWithTooltip
+                                      className="item-card-button-icon component-rename-button"
+                                      data-testid="component-rename-button"
+                                      alt={intl.formatMessage(cardHeaderMessages.altButtonRename)}
+                                      tooltipContent={(
+                                        <div>{intl.formatMessage(cardHeaderMessages.altButtonRename)}</div>
+                                      )}
+                                      iconAs={EditIcon}
+                                      onClick={(e: React.MouseEvent) => {
+                                        e.stopPropagation();
+                                        handleRenameStart(component.blockId, component.displayName);
+                                      }}
+                                      onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                                      // @ts-ignore
+                                      disabled={isRenamePending}
+                                    />
+                                  </Stack>
+                                )}
+                                <Stack
+                                  direction="horizontal"
+                                  gap={2}
+                                  className="component-header-actions d-flex align-items-center flex-shrink-0 ml-auto"
+                                >
+                                  <OverlayTrigger
+                                    placement="top"
+                                    overlay={(
+                                      <Tooltip id={`edit-tooltip-${component.blockId}`}>
+                                        {intl.formatMessage(messages.editComponent)}
+                                      </Tooltip>
+                                    )}
+                                  >
+                                    <Button
+                                      as="a"
+                                      href={getComponentEditorUrl(component.blockType, component.blockId)}
+                                      variant="outline-primary"
+                                      size="sm"
+                                      className="component-edit-button"
+                                      data-testid="component-edit-button"
+                                      onClick={(e: React.MouseEvent) => {
+                                        e.stopPropagation();
+                                        if (!e.metaKey && !e.ctrlKey) {
+                                          e.preventDefault();
+                                          handleComponentEdit(e, component.blockType, component.blockId);
+                                        }
+                                      }}
+                                      onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                                    >
+                                      {intl.formatMessage(messages.editButton)}
+                                    </Button>
+                                  </OverlayTrigger>
+                                  <ComponentMenu
+                                    unitId={id}
+                                    blockId={component.blockId}
+                                    displayName={component.displayName}
+                                    blockType={component.blockType}
+                                    userPartitionInfo={component.userPartitionInfo}
+                                    userPartitions={component.userPartitions}
+                                    actions={component.actions ?? EMPTY_UNIT_COMPONENT_ACTIONS}
+                                    onActionComplete={handleComponentActionComplete}
+                                    isMenuOpen={openComponentMenuBlockId === component.blockId}
+                                    onMenuToggle={setOpenComponentMenuBlockId}
+                                  />
+                                </Stack>
                               </>
                             )}
                           />

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -139,7 +139,7 @@ const UnitCard = ({
     upstreamInfo,
   } = unit;
 
-  const { mutateAsync: renameComponent, isPending: isRenamePending } = useRenameUnitComponent(id);
+  const { mutateAsync: renameComponent, isPending: isRenamePending } = useRenameUnitComponent();
 
   // Fetch unit components when expanded (only if flag is enabled)
   const {

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -4,6 +4,7 @@ import {
   createCourseXblock,
   deleteUnitItem,
   duplicateUnitItem,
+  editUnitDisplayName,
 } from '@src/course-unit/data/api';
 import { getUnitHandler, getComponentTemplates } from './api';
 
@@ -75,3 +76,15 @@ export const useDeleteUnitComponent = (unitId: string) => (
 export const useDuplicateUnitComponent = (unitId: string) => (
   useUnitComponentMutation(unitId, (blockId) => duplicateUnitItem(unitId, blockId))
 );
+
+export const useRenameUnitComponent = (unitId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ blockId, displayName }: { blockId: string; displayName: string }) => (
+      editUnitDisplayName(blockId, displayName)
+    ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: unitHandlerQueryKey(unitId) });
+    },
+  });
+};

--- a/src/course-outline/unit-card/data/hooks.ts
+++ b/src/course-outline/unit-card/data/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { camelCaseObject } from '@edx/frontend-platform';
 import {
   createCourseXblock,
@@ -30,61 +30,37 @@ export const useComponentTemplates = (
   staleTime: 5 * 60 * 1000, // 5 minutes — templates rarely change within a session
 });
 
-// Hook to create a new xblock component inside a unit, reusing the course-unit API
-export const useCreateXBlockInUnit = (unitId: string) => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    // Wrap createCourseXblock to normalize the response with camelCase keys
-    mutationFn: async (params: {
-      parentLocator: string;
-      type: string;
-      category?: string;
-      boilerplate?: string;
-    }) => {
-      const data = await createCourseXblock({
-        type: params.type,
-        category: params.category,
-        parentLocator: params.parentLocator,
-        boilerplate: params.boilerplate,
-      });
-      // Normalize snake_case response (locator, course_key) to camelCase
-      return camelCaseObject(data) as { locator: string; courseKey: string };
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: unitHandlerQueryKey(unitId) });
-    },
-  });
-};
+export const useCreateXBlockInUnit = () => useMutation({
+  mutationFn: async (params: {
+    parentLocator: string;
+    type: string;
+    category?: string;
+    boilerplate?: string;
+  }) => {
+    const data = await createCourseXblock({
+      type: params.type,
+      category: params.category,
+      parentLocator: params.parentLocator,
+      boilerplate: params.boilerplate,
+    });
+    return camelCaseObject(data) as { locator: string; courseKey: string };
+  },
+});
 
 const useUnitComponentMutation = <T>(
-  unitId: string,
   mutationFn: (blockId: string) => Promise<T>,
-) => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: unitHandlerQueryKey(unitId) });
-    },
-  });
-};
+) => useMutation({ mutationFn });
 
-export const useDeleteUnitComponent = (unitId: string) => (
-  useUnitComponentMutation(unitId, deleteUnitItem)
+export const useDeleteUnitComponent = () => (
+  useUnitComponentMutation(deleteUnitItem)
 );
 
 export const useDuplicateUnitComponent = (unitId: string) => (
-  useUnitComponentMutation(unitId, (blockId) => duplicateUnitItem(unitId, blockId))
+  useUnitComponentMutation((blockId) => duplicateUnitItem(unitId, blockId))
 );
 
-export const useRenameUnitComponent = (unitId: string) => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ blockId, displayName }: { blockId: string; displayName: string }) => (
-      editUnitDisplayName(blockId, displayName)
-    ),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: unitHandlerQueryKey(unitId) });
-    },
-  });
-};
+export const useRenameUnitComponent = () => useMutation({
+  mutationFn: ({ blockId, displayName }: { blockId: string; displayName: string }) => (
+    editUnitDisplayName(blockId, displayName)
+  ),
+});

--- a/src/course-outline/unit-card/messages.js
+++ b/src/course-outline/unit-card/messages.js
@@ -96,6 +96,16 @@ const messages = defineMessages({
     defaultMessage: 'Failed to delete component. Please try again.',
     description: 'Error message shown when deleting a component from the outline fails',
   },
+  componentRenameError: {
+    id: 'course-authoring.course-outline.unit.component-rename-error',
+    defaultMessage: 'Failed to rename component. Please try again.',
+    description: 'Error message shown when renaming a component from the outline fails',
+  },
+  editButton: {
+    id: 'course-authoring.course-outline.unit.edit-button',
+    defaultMessage: 'Edit',
+    description: 'Label for the button to edit a component',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
- Introduced a new inline rename feature for components in UnitCard, allowing users to edit component names directly.
- Updated ComponentMenu to manage menu state and actions more effectively, including closing menus when another is opened.
- Added tests to verify the new rename functionality and menu behavior.
- Enhanced styles for better UI/UX in the component layout.
- Added new messages for internationalization related to renaming components.

## Description

Adds inline rename functionality for components in the course outline, allowing Course Authors to rename components directly from the UnitCard without navigating away.

**User roles impacted:** Course Author

### Changes
- **UnitCard**: Added inline rename UI - clicking "Rename" from the component menu switches the component title into an editable input field.
- **ComponentMenu**: Refactored menu state management to auto-close sibling menus when a new one is opened, preventing multiple menus from being open simultaneously.
- **Styles**: UI/UX polish for the component layout to accommodate the inline editing state.
- **i18n**: New messages added for rename-related UI strings.
- **Tests**: Added unit tests covering the rename flow and menu open/close behavior.

## Screen recording:
https://github.com/user-attachments/assets/7fe83b50-49fb-459f-8a81-e80b5b94a1c3

## Supporting Information

Jira ticket: [TNL2-619](https://2u-internal.atlassian.net/browse/TNL2-619)

## Testing Instructions
1. Navigate to the course outline in Studio.
2. Expand a unit to see its components.
3. Click the kebab/action menu on any component.
4. Select **Rename** - the component title should become an editable input inline.
5. Type a new name and confirm - the component should reflect the updated name.
6. Open a second component's menu - the first menu should auto-close.

