### PR TITLE
feat: implement send email on release notes publish

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,6 +26,7 @@ import {
 import initializeStore from './store';
 import CourseAuthoringRoutes from './CourseAuthoringRoutes';
 import ReleaseNotes from './release-notes/ReleaseNotes';
+import ReleaseNoteUnsubscribe from './release-notes/unsubscribe/ReleaseNoteUnsubscribe';
 import Head from './head/Head';
 import { StudioHome } from './studio-home';
 import CourseRerun from './course-rerun';
@@ -97,6 +98,7 @@ const App = () => {
         {getConfig().ENABLE_RELEASE_NOTES === 'true' && (
           <Route path="/release-notes" element={<ReleaseNotes />} />
         )}
+        <Route path="/release-notes/unsubscribe" element={<ReleaseNoteUnsubscribe />} />
         {getConfig().ENABLE_ACCESSIBILITY_PAGE === 'true' && (
           <Route path="/accessibility" element={<AccessibilityPage />} />
         )}

--- a/src/release-notes/ReleaseNotes.jsx
+++ b/src/release-notes/ReleaseNotes.jsx
@@ -36,6 +36,7 @@ const ReleaseNotes = () => {
     requestType,
     notes,
     hasAccess,
+    canSendReleaseNoteEmails,
     notesInitialValues,
     isFormOpen,
     isDeleteModalOpen,
@@ -277,6 +278,7 @@ const ReleaseNotes = () => {
             initialValues={notesInitialValues}
             close={closeForm}
             onSubmit={handleUpdatesSubmit}
+            canSendReleaseNoteEmails={canSendReleaseNoteEmails}
             savingStatuses={savingStatuses}
             isDirtyCheckRef={isDirtyCheckRef}
             showUnsavedModalRef={showUnsavedModalRef}

--- a/src/release-notes/ReleaseNotes.test.jsx
+++ b/src/release-notes/ReleaseNotes.test.jsx
@@ -22,6 +22,7 @@ const mockUseReleaseNotes = {
   requestType: null,
   notes: [],
   hasAccess: false,
+  canSendReleaseNoteEmails: false,
   notesInitialValues: {},
   isFormOpen: false,
   isDeleteModalOpen: false,

--- a/src/release-notes/data/api.js
+++ b/src/release-notes/data/api.js
@@ -5,6 +5,7 @@ const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
 const getReleaseNotesApiUrl = () => new URL('/api/release_notes/v1/posts/', getApiBaseUrl()).href;
 const getReleaseNoteApiUrl = (id) => new URL(`/api/release_notes/v1/posts/${id}/`, getApiBaseUrl()).href;
+const getUnsubscribeApiUrl = () => new URL('/api/release_notes/v1/email/unsubscribe/', getApiBaseUrl()).href;
 
 export async function getReleaseNotes() {
   const { data } = await getAuthenticatedHttpClient().get(getReleaseNotesApiUrl());
@@ -23,5 +24,11 @@ export async function editReleaseNote(note) {
 
 export async function deleteReleaseNote(id) {
   const { data } = await getAuthenticatedHttpClient().delete(getReleaseNoteApiUrl(id));
+  return camelCaseObject(data);
+}
+
+export async function unsubscribeWithToken(token) {
+  const url = `${getUnsubscribeApiUrl()}?token=${encodeURIComponent(token)}`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
   return camelCaseObject(data);
 }

--- a/src/release-notes/data/api.js
+++ b/src/release-notes/data/api.js
@@ -27,7 +27,7 @@ export async function deleteReleaseNote(id) {
   return camelCaseObject(data);
 }
 
-export async function unsubscribeWithToken(token) {
+export async function unsubscribeFromReleaseNoteEmails(token) {
   const url = `${getUnsubscribeApiUrl()}?token=${encodeURIComponent(token)}`;
   const { data } = await getAuthenticatedHttpClient().get(url);
   return camelCaseObject(data);

--- a/src/release-notes/data/api.js
+++ b/src/release-notes/data/api.js
@@ -27,8 +27,7 @@ export async function deleteReleaseNote(id) {
   return camelCaseObject(data);
 }
 
-export async function unsubscribeFromReleaseNoteEmails(token) {
-  const url = `${getUnsubscribeApiUrl()}?token=${encodeURIComponent(token)}`;
-  const { data } = await getAuthenticatedHttpClient().get(url);
+export async function unsubscribeFromReleaseNoteEmails() {
+  const { data } = await getAuthenticatedHttpClient().get(getUnsubscribeApiUrl());
   return camelCaseObject(data);
 }

--- a/src/release-notes/data/api.test.js
+++ b/src/release-notes/data/api.test.js
@@ -8,7 +8,7 @@ import {
   createReleaseNote,
   editReleaseNote,
   deleteReleaseNote,
-  unsubscribeWithToken,
+  unsubscribeFromReleaseNoteEmails,
 } from './api';
 
 describe('release-notes api', () => {
@@ -58,13 +58,13 @@ describe('release-notes api', () => {
     await expect(getReleaseNotes()).rejects.toBeTruthy();
   });
 
-  test('unsubscribeWithToken issues GET with the token query param', async () => {
+  test('unsubscribeFromReleaseNoteEmails issues authenticated GET with token', async () => {
     const token = 'abc 123/=';
     const baseUrl = new URL('/api/release_notes/v1/email/unsubscribe/', getConfig().STUDIO_BASE_URL).href;
     const expectedUrl = `${baseUrl}?token=${encodeURIComponent(token)}`;
-    mock.onGet(expectedUrl).reply(200, { result_status: 'unsubscribed' });
-    const res = await unsubscribeWithToken(token);
-    expect(res.resultStatus).toBe('unsubscribed');
+    mock.onGet(expectedUrl).reply(200, { message: 'unsubscribed' });
+    const res = await unsubscribeFromReleaseNoteEmails(token);
+    expect(res.message).toBe('unsubscribed');
     expect(mock.history.get[0].url).toBe(expectedUrl);
   });
 });

--- a/src/release-notes/data/api.test.js
+++ b/src/release-notes/data/api.test.js
@@ -58,12 +58,10 @@ describe('release-notes api', () => {
     await expect(getReleaseNotes()).rejects.toBeTruthy();
   });
 
-  test('unsubscribeFromReleaseNoteEmails issues authenticated GET with token', async () => {
-    const token = 'abc 123/=';
-    const baseUrl = new URL('/api/release_notes/v1/email/unsubscribe/', getConfig().STUDIO_BASE_URL).href;
-    const expectedUrl = `${baseUrl}?token=${encodeURIComponent(token)}`;
+  test('unsubscribeFromReleaseNoteEmails issues authenticated GET', async () => {
+    const expectedUrl = new URL('/api/release_notes/v1/email/unsubscribe/', getConfig().STUDIO_BASE_URL).href;
     mock.onGet(expectedUrl).reply(200, { message: 'unsubscribed' });
-    const res = await unsubscribeFromReleaseNoteEmails(token);
+    const res = await unsubscribeFromReleaseNoteEmails();
     expect(res.message).toBe('unsubscribed');
     expect(mock.history.get[0].url).toBe(expectedUrl);
   });

--- a/src/release-notes/data/api.test.js
+++ b/src/release-notes/data/api.test.js
@@ -4,7 +4,11 @@ import MockAdapter from 'axios-mock-adapter';
 
 import { initializeMocks } from '../../testUtils';
 import {
-  getReleaseNotes, createReleaseNote, editReleaseNote, deleteReleaseNote,
+  getReleaseNotes,
+  createReleaseNote,
+  editReleaseNote,
+  deleteReleaseNote,
+  unsubscribeWithToken,
 } from './api';
 
 describe('release-notes api', () => {
@@ -52,5 +56,15 @@ describe('release-notes api', () => {
     const url = new URL('/api/release_notes/v1/posts/', getConfig().STUDIO_BASE_URL).href;
     mock.onGet(url).reply(500, {});
     await expect(getReleaseNotes()).rejects.toBeTruthy();
+  });
+
+  test('unsubscribeWithToken issues GET with the token query param', async () => {
+    const token = 'abc 123/=';
+    const baseUrl = new URL('/api/release_notes/v1/email/unsubscribe/', getConfig().STUDIO_BASE_URL).href;
+    const expectedUrl = `${baseUrl}?token=${encodeURIComponent(token)}`;
+    mock.onGet(expectedUrl).reply(200, { result_status: 'unsubscribed' });
+    const res = await unsubscribeWithToken(token);
+    expect(res.resultStatus).toBe('unsubscribed');
+    expect(mock.history.get[0].url).toBe(expectedUrl);
   });
 });

--- a/src/release-notes/data/selectors.js
+++ b/src/release-notes/data/selectors.js
@@ -1,5 +1,6 @@
 export const getReleaseNotes = (state) => state.releaseNotes.releaseNotes;
 export const getHasAccess = (state) => state.releaseNotes.hasAccess;
+export const getCanSendReleaseNoteEmails = (state) => state.releaseNotes.canSendReleaseNoteEmails;
 export const getSavingStatuses = (state) => state.releaseNotes.savingStatuses;
 export const getLoadingStatuses = (state) => state.releaseNotes.loadingStatuses;
 export const getErrors = (state) => state.releaseNotes.errors;

--- a/src/release-notes/data/slice.js
+++ b/src/release-notes/data/slice.js
@@ -5,6 +5,7 @@ import { sortBy } from 'lodash';
 const initialState = {
   releaseNotes: [],
   hasAccess: false,
+  canSendReleaseNoteEmails: false,
   savingStatuses: {
     createReleaseNoteQuery: '',
     editReleaseNoteQuery: '',
@@ -28,6 +29,7 @@ const slice = createSlice({
     fetchReleaseNotesSuccess: (state, { payload }) => {
       state.releaseNotes = payload.notes || payload;
       state.hasAccess = payload.hasAccess || false;
+      state.canSendReleaseNoteEmails = payload.canSendReleaseNoteEmails || false;
     },
     createReleaseNote: (state, { payload }) => {
       state.releaseNotes = [payload, ...state.releaseNotes];

--- a/src/release-notes/data/thunk.js
+++ b/src/release-notes/data/thunk.js
@@ -23,6 +23,7 @@ export function fetchReleaseNotesQuery() {
       const response = await getReleaseNotes();
       const notesList = Array.isArray(response) ? response : (response.results || []);
       const hasAccess = response.hasAccess || false;
+      const canSendReleaseNoteEmails = response.canSendReleaseNoteEmails || false;
       const normalized = (notesList || []).map((n) => ({
         id: n.id,
         title: n.title,
@@ -35,7 +36,9 @@ export function fetchReleaseNotesQuery() {
           const tb = b.published_at ? Date.parse(b.published_at) : -Infinity;
           return tb - ta;
         });
-      dispatch(fetchReleaseNotesSuccess({ notes: normalized, hasAccess }));
+      dispatch(fetchReleaseNotesSuccess({
+        notes: normalized, hasAccess, canSendReleaseNoteEmails,
+      }));
       dispatch(updateLoadingStatuses({
         status: { fetchReleaseNotesQuery: RequestStatus.SUCCESSFUL },
         error: { loadingNotes: false },
@@ -57,9 +60,11 @@ export function createReleaseNoteQuery(data) {
         error: {},
       }));
       dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
+      const { sendEmail, ...noteData } = data;
       const payload = {
-        ...data,
-        raw_html_content: data.description,
+        ...noteData,
+        raw_html_content: noteData.description,
+        send_email_on_publish: sendEmail || false,
       };
       delete payload.description;
       const note = await createReleaseNote(payload);
@@ -96,9 +101,11 @@ export function editReleaseNoteQuery(data) {
         error: {},
       }));
       dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
+      const { sendEmail, ...noteData } = data;
       const payload = {
-        ...data,
-        raw_html_content: data.description,
+        ...noteData,
+        raw_html_content: noteData.description,
+        send_email_on_publish: sendEmail || false,
       };
       delete payload.description;
       const note = await editReleaseNote(payload);

--- a/src/release-notes/data/thunk.js
+++ b/src/release-notes/data/thunk.js
@@ -16,6 +16,17 @@ import {
   updateSavingStatuses,
 } from './slice';
 
+function normalizeReleaseNote(note) {
+  return {
+    id: note.id,
+    title: note.title,
+    description: note.rawHtmlContent,
+    published_at: note.publishedAt,
+    created_by: note.createdBy,
+    sendEmail: Boolean(note.sendEmailOnPublish),
+  };
+}
+
 export function fetchReleaseNotesQuery() {
   return async (dispatch) => {
     try {
@@ -24,13 +35,7 @@ export function fetchReleaseNotesQuery() {
       const notesList = Array.isArray(response) ? response : (response.results || []);
       const hasAccess = response.hasAccess || false;
       const canSendReleaseNoteEmails = response.canSendReleaseNoteEmails || false;
-      const normalized = (notesList || []).map((n) => ({
-        id: n.id,
-        title: n.title,
-        description: n.rawHtmlContent,
-        published_at: n.publishedAt,
-        created_by: n.createdBy,
-      }))
+      const normalized = (notesList || []).map(normalizeReleaseNote)
         .sort((a, b) => {
           const ta = a.published_at ? Date.parse(a.published_at) : -Infinity;
           const tb = b.published_at ? Date.parse(b.published_at) : -Infinity;
@@ -68,14 +73,7 @@ export function createReleaseNoteQuery(data) {
       };
       delete payload.description;
       const note = await createReleaseNote(payload);
-      const normalized = {
-        id: note.id,
-        title: note.title,
-        description: note.rawHtmlContent,
-        published_at: note.publishedAt,
-        created_by: note.createdBy,
-      };
-      dispatch(createReleaseNoteAction(normalized));
+      dispatch(createReleaseNoteAction(normalizeReleaseNote(note)));
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createReleaseNoteQuery: RequestStatus.SUCCESSFUL },
@@ -109,14 +107,7 @@ export function editReleaseNoteQuery(data) {
       };
       delete payload.description;
       const note = await editReleaseNote(payload);
-      const normalized = {
-        id: note.id,
-        title: note.title,
-        description: note.rawHtmlContent,
-        published_at: note.publishedAt,
-        created_by: note.createdBy,
-      };
-      dispatch(editReleaseNoteAction(normalized));
+      dispatch(editReleaseNoteAction(normalizeReleaseNote(note)));
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { editReleaseNoteQuery: RequestStatus.SUCCESSFUL },

--- a/src/release-notes/data/thunk.test.js
+++ b/src/release-notes/data/thunk.test.js
@@ -43,9 +43,28 @@ describe('release-notes thunks', () => {
     expect(success.payload.notes[0].id).toBe(2);
     expect(success.payload.notes[0]).toEqual(expect.objectContaining({ description: '<p>b</p>', published_at: expect.any(String), created_by: 'b@x' }));
     expect(success.payload.hasAccess).toBe(false);
+    expect(success.payload.canSendReleaseNoteEmails).toBe(false);
     const last = actions[actions.length - 1];
     expect(last.type).toBe(updateLoadingStatuses.type);
     expect(last.payload.status.fetchReleaseNotesQuery).toBe(RequestStatus.SUCCESSFUL);
+  });
+
+  test('fetchReleaseNotesQuery reads hasAccess and canSendReleaseNoteEmails from paginated response', async () => {
+    jest.spyOn(api, 'getReleaseNotes').mockResolvedValue({
+      results: [{
+        id: 1, title: 'a', rawHtmlContent: '<p>a</p>', publishedAt: '2025-01-01T00:00:00Z', createdBy: 'a@x',
+      }],
+      hasAccess: true,
+      canSendReleaseNoteEmails: true,
+    });
+    const { actions, dispatch } = collectActions();
+
+    await fetchReleaseNotesQuery()(dispatch);
+
+    const success = actions.find(a => a.type === fetchReleaseNotesSuccess.type);
+    expect(success.payload.hasAccess).toBe(true);
+    expect(success.payload.canSendReleaseNoteEmails).toBe(true);
+    expect(success.payload.notes).toHaveLength(1);
   });
 
   test('fetchReleaseNotesQuery failure sets FAILED', async () => {
@@ -156,5 +175,39 @@ describe('release-notes thunks', () => {
     await editReleaseNoteQuery({ id: 2, title: 't2', description: '<p>y</p>' })(dispatch);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ raw_html_content: '<p>y</p>' }));
     expect(spy).toHaveBeenCalledWith(expect.not.objectContaining({ description: expect.anything() }));
+  });
+
+  test('createReleaseNoteQuery maps sendEmail to send_email_on_publish (true)', async () => {
+    const spy = jest.spyOn(api, 'createReleaseNote').mockResolvedValue({ id: 1, title: 't', rawHtmlContent: '<p>x</p>' });
+    const { dispatch } = collectActions();
+    await createReleaseNoteQuery({
+      id: 1, title: 't', description: '<p>x</p>', sendEmail: true,
+    })(dispatch);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ send_email_on_publish: true }));
+    expect(spy).toHaveBeenCalledWith(expect.not.objectContaining({ sendEmail: expect.anything() }));
+  });
+
+  test('createReleaseNoteQuery defaults send_email_on_publish to false when sendEmail absent', async () => {
+    const spy = jest.spyOn(api, 'createReleaseNote').mockResolvedValue({ id: 1, title: 't', rawHtmlContent: '<p>x</p>' });
+    const { dispatch } = collectActions();
+    await createReleaseNoteQuery({ id: 1, title: 't', description: '<p>x</p>' })(dispatch);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ send_email_on_publish: false }));
+  });
+
+  test('editReleaseNoteQuery maps sendEmail to send_email_on_publish (true)', async () => {
+    const spy = jest.spyOn(api, 'editReleaseNote').mockResolvedValue({ id: 2, title: 't2', rawHtmlContent: '<p>y</p>' });
+    const { dispatch } = collectActions();
+    await editReleaseNoteQuery({
+      id: 2, title: 't2', description: '<p>y</p>', sendEmail: true,
+    })(dispatch);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ send_email_on_publish: true }));
+    expect(spy).toHaveBeenCalledWith(expect.not.objectContaining({ sendEmail: expect.anything() }));
+  });
+
+  test('editReleaseNoteQuery defaults send_email_on_publish to false when sendEmail absent', async () => {
+    const spy = jest.spyOn(api, 'editReleaseNote').mockResolvedValue({ id: 2, title: 't2', rawHtmlContent: '<p>y</p>' });
+    const { dispatch } = collectActions();
+    await editReleaseNoteQuery({ id: 2, title: 't2', description: '<p>y</p>' })(dispatch);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ send_email_on_publish: false }));
   });
 });

--- a/src/release-notes/data/thunk.test.js
+++ b/src/release-notes/data/thunk.test.js
@@ -49,6 +49,34 @@ describe('release-notes thunks', () => {
     expect(last.payload.status.fetchReleaseNotesQuery).toBe(RequestStatus.SUCCESSFUL);
   });
 
+  test('fetchReleaseNotesQuery maps sendEmailOnPublish to sendEmail', async () => {
+    jest.spyOn(api, 'getReleaseNotes').mockResolvedValue([
+      {
+        id: 1,
+        title: 'a',
+        rawHtmlContent: '<p>a</p>',
+        publishedAt: '2025-01-01T00:00:00Z',
+        createdBy: 'a@x',
+        sendEmailOnPublish: true,
+      },
+      {
+        id: 2,
+        title: 'b',
+        rawHtmlContent: '<p>b</p>',
+        publishedAt: '2025-01-02T00:00:00Z',
+        createdBy: 'b@x',
+        sendEmailOnPublish: false,
+      },
+    ]);
+    const { actions, dispatch } = collectActions();
+
+    await fetchReleaseNotesQuery()(dispatch);
+
+    const success = actions.find(a => a.type === fetchReleaseNotesSuccess.type);
+    expect(success.payload.notes.find(n => n.id === 1).sendEmail).toBe(true);
+    expect(success.payload.notes.find(n => n.id === 2).sendEmail).toBe(false);
+  });
+
   test('fetchReleaseNotesQuery reads hasAccess and canSendReleaseNoteEmails from paginated response', async () => {
     jest.spyOn(api, 'getReleaseNotes').mockResolvedValue({
       results: [{
@@ -79,11 +107,20 @@ describe('release-notes thunks', () => {
 
   test('createReleaseNoteQuery success creates note and sets SUCCESSFUL', async () => {
     jest.spyOn(api, 'createReleaseNote').mockResolvedValue({
-      id: 9, title: 't', rawHtmlContent: '<p>x</p>', publishedAt: '2025-01-01T00:00:00Z', createdBy: 'u',
+      id: 9,
+      title: 't',
+      rawHtmlContent: '<p>x</p>',
+      publishedAt: '2025-01-01T00:00:00Z',
+      createdBy: 'u',
+      sendEmailOnPublish: true,
     });
     const { actions, dispatch } = collectActions();
-    await createReleaseNoteQuery({ id: 9, title: 't', description: '<p>x</p>' })(dispatch);
-    expect(actions.find(a => a.type === createReleaseNoteAction.type)).toBeTruthy();
+    await createReleaseNoteQuery({
+      id: 9, title: 't', description: '<p>x</p>', sendEmail: true,
+    })(dispatch);
+    const created = actions.find(a => a.type === createReleaseNoteAction.type);
+    expect(created).toBeTruthy();
+    expect(created.payload.sendEmail).toBe(true);
     const last = actions[actions.length - 1];
     expect(last.type).toBe(updateSavingStatuses.type);
     expect(last.payload.status.createReleaseNoteQuery).toBe(RequestStatus.SUCCESSFUL);
@@ -111,11 +148,20 @@ describe('release-notes thunks', () => {
 
   test('editReleaseNoteQuery success edits note and sets SUCCESSFUL', async () => {
     jest.spyOn(api, 'editReleaseNote').mockResolvedValue({
-      id: 5, title: 't2', rawHtmlContent: '<p>y</p>', publishedAt: '2025-01-03T00:00:00Z', createdBy: 'v',
+      id: 5,
+      title: 't2',
+      rawHtmlContent: '<p>y</p>',
+      publishedAt: '2025-01-03T00:00:00Z',
+      createdBy: 'v',
+      sendEmailOnPublish: true,
     });
     const { actions, dispatch } = collectActions();
-    await editReleaseNoteQuery({ id: 5, title: 't2', description: '<p>y</p>' })(dispatch);
-    expect(actions.find(a => a.type === editReleaseNoteAction.type)).toBeTruthy();
+    await editReleaseNoteQuery({
+      id: 5, title: 't2', description: '<p>y</p>', sendEmail: true,
+    })(dispatch);
+    const edited = actions.find(a => a.type === editReleaseNoteAction.type);
+    expect(edited).toBeTruthy();
+    expect(edited.payload.sendEmail).toBe(true);
     const last = actions[actions.length - 1];
     expect(last.type).toBe(updateSavingStatuses.type);
     expect(last.payload.status.editReleaseNoteQuery).toBe(RequestStatus.SUCCESSFUL);

--- a/src/release-notes/hooks.jsx
+++ b/src/release-notes/hooks.jsx
@@ -13,6 +13,7 @@ import {
 import {
   getReleaseNotes as selectReleaseNotes,
   getHasAccess,
+  getCanSendReleaseNoteEmails,
   getLoadingStatuses,
   getSavingStatuses,
   getErrors,
@@ -31,6 +32,7 @@ const useReleaseNotes = () => {
 
   const notes = useSelector(selectReleaseNotes) || [];
   const hasAccess = useSelector(getHasAccess);
+  const canSendReleaseNoteEmails = useSelector(getCanSendReleaseNoteEmails);
   const loadingStatuses = useSelector(getLoadingStatuses);
   const savingStatuses = useSelector(getSavingStatuses);
   const errors = useSelector(getErrors);
@@ -105,6 +107,7 @@ const useReleaseNotes = () => {
     requestType,
     notes,
     hasAccess,
+    canSendReleaseNoteEmails,
     notesInitialValues,
     isMainFormOpen: isFormOpen && requestType !== REQUEST_TYPES.edit_update,
     isInnerFormOpen: (id) => (

--- a/src/release-notes/messages.js
+++ b/src/release-notes/messages.js
@@ -106,6 +106,14 @@ const messages = defineMessages({
     id: 'release-notes.form.error.description.required',
     defaultMessage: 'Enter post content',
   },
+  sendEmailCheckboxLabel: {
+    id: 'release-notes.form.send-email.label',
+    defaultMessage: 'Send email notification to all course authors',
+  },
+  sendEmailCheckboxHelp: {
+    id: 'release-notes.form.send-email.help',
+    defaultMessage: 'When checked, an email will be sent to all course authors on the platform notifying them of this release note.',
+  },
 });
 
 export default messages;

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import {
   Alert, Button, Card, Container, Spinner,
 } from '@openedx/paragon';
@@ -10,21 +9,12 @@ import messages from './messages';
 
 const ReleaseNoteUnsubscribe = () => {
   const intl = useIntl();
-  const location = useLocation();
   const [status, setStatus] = useState('idle'); // idle, loading, success, error
 
-  const params = new URLSearchParams(location.search);
-  const token = params.get('token');
-
   const handleUnsubscribe = () => {
-    if (!token) {
-      setStatus('error');
-      return;
-    }
-
     setStatus('loading');
 
-    unsubscribeFromReleaseNoteEmails(token)
+    unsubscribeFromReleaseNoteEmails()
       .then(() => {
         setStatus('success');
       })
@@ -32,16 +22,6 @@ const ReleaseNoteUnsubscribe = () => {
         setStatus('error');
       });
   };
-
-  if (!token) {
-    return (
-      <Container size="sm" className="py-5">
-        <Alert variant="danger" icon={Info}>
-          {intl.formatMessage(messages.unsubscribeError)}
-        </Alert>
-      </Container>
-    );
-  }
 
   return (
     <Container size="sm" className="d-flex align-items-center justify-content-center py-5">

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
@@ -5,7 +5,7 @@ import {
 } from '@openedx/paragon';
 import { Info, CheckCircle, Email } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { unsubscribeWithToken } from '../data/api';
+import { unsubscribeFromReleaseNoteEmails } from '../data/api';
 import messages from './messages';
 
 const ReleaseNoteUnsubscribe = () => {
@@ -24,7 +24,7 @@ const ReleaseNoteUnsubscribe = () => {
 
     setStatus('loading');
 
-    unsubscribeWithToken(token)
+    unsubscribeFromReleaseNoteEmails(token)
       .then(() => {
         setStatus('success');
       })
@@ -82,7 +82,7 @@ const ReleaseNoteUnsubscribe = () => {
           variant="danger"
           icon={Info}
           actions={[
-            <Button variant="outline-primary" onClick={handleUnsubscribe}>
+            <Button key="unsubscribe-retry" type="button" variant="outline-primary" onClick={handleUnsubscribe}>
               {intl.formatMessage(messages.unsubscribeRetry)}
             </Button>,
           ]}

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  Alert, Button, Card, Container, Spinner,
+} from '@openedx/paragon';
+import { Info, CheckCircle, Email } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { unsubscribeWithToken } from '../data/api';
+import messages from './messages';
+
+const ReleaseNoteUnsubscribe = () => {
+  const intl = useIntl();
+  const location = useLocation();
+  const [status, setStatus] = useState('idle'); // idle, loading, success, error
+
+  const params = new URLSearchParams(location.search);
+  const token = params.get('token');
+
+  const handleUnsubscribe = () => {
+    if (!token) {
+      setStatus('error');
+      return;
+    }
+
+    setStatus('loading');
+
+    unsubscribeWithToken(token)
+      .then(() => {
+        setStatus('success');
+      })
+      .catch(() => {
+        setStatus('error');
+      });
+  };
+
+  if (!token) {
+    return (
+      <Container size="sm" className="py-5">
+        <Alert variant="danger" icon={Info}>
+          {intl.formatMessage(messages.unsubscribeError)}
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="sm" className="d-flex align-items-center justify-content-center py-5">
+      {status === 'idle' && (
+        <Card className="text-center shadow-sm" style={{ maxWidth: '480px' }}>
+          <Card.Section className="p-4">
+            <Alert variant="warning" icon={Email} className="mb-3">
+              {intl.formatMessage(messages.unsubscribeTitle)}
+            </Alert>
+            <p className="text-gray-700 mb-4">
+              {intl.formatMessage(messages.unsubscribeConfirmation)}
+            </p>
+            <Button variant="primary" onClick={handleUnsubscribe} block>
+              {intl.formatMessage(messages.unsubscribeButton)}
+            </Button>
+            <p className="x-small text-gray-500 mt-3 mb-0">
+              {intl.formatMessage(messages.unsubscribeDisclaimer)}
+            </p>
+          </Card.Section>
+        </Card>
+      )}
+      {status === 'loading' && (
+        <Card className="text-center shadow-sm" style={{ maxWidth: '480px' }}>
+          <Card.Section className="p-4">
+            <Spinner animation="border" className="mb-3" screenReaderText={intl.formatMessage(messages.unsubscribeProcessing)} />
+            <p className="text-gray-700 mb-0">{intl.formatMessage(messages.unsubscribeProcessing)}</p>
+          </Card.Section>
+        </Card>
+      )}
+      {status === 'success' && (
+        <Alert variant="success" icon={CheckCircle}>
+          <Alert.Heading>{intl.formatMessage(messages.unsubscribeSuccessTitle)}</Alert.Heading>
+          <p className="mb-0">{intl.formatMessage(messages.unsubscribeSuccess)}</p>
+        </Alert>
+      )}
+      {status === 'error' && (
+        <Alert
+          variant="danger"
+          icon={Info}
+          actions={[
+            <Button variant="outline-primary" onClick={handleUnsubscribe}>
+              {intl.formatMessage(messages.unsubscribeRetry)}
+            </Button>,
+          ]}
+        >
+          <Alert.Heading>{intl.formatMessage(messages.unsubscribeErrorTitle)}</Alert.Heading>
+          <p className="mb-0">{intl.formatMessage(messages.unsubscribeError)}</p>
+        </Alert>
+      )}
+    </Container>
+  );
+};
+
+export default ReleaseNoteUnsubscribe;

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  render, screen, fireEvent, initializeMocks, waitFor,
+} from '../../testUtils';
+
+import ReleaseNoteUnsubscribe from './ReleaseNoteUnsubscribe';
+import messages from './messages';
+import * as api from '../data/api';
+
+const renderWithToken = (token) => {
+  const initialEntries = token === undefined
+    ? ['/release-notes/unsubscribe']
+    : [`/release-notes/unsubscribe?token=${encodeURIComponent(token)}`];
+  return render(<ReleaseNoteUnsubscribe />, {
+    routerProps: { initialEntries },
+  });
+};
+
+describe('ReleaseNoteUnsubscribe', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  test('shows error alert when no token is present', () => {
+    renderWithToken(undefined);
+    expect(screen.getByText(messages.unsubscribeError.defaultMessage)).toBeInTheDocument();
+    // The confirmation CTA should not be rendered without a token
+    expect(
+      screen.queryByRole('button', { name: messages.unsubscribeButton.defaultMessage }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the idle confirmation state when a token is present', () => {
+    renderWithToken('valid-token');
+    expect(screen.getByText(messages.unsubscribeTitle.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.unsubscribeConfirmation.defaultMessage)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }),
+    ).toBeInTheDocument();
+  });
+
+  test('calls unsubscribeWithToken and shows success state on success', async () => {
+    const spy = jest.spyOn(api, 'unsubscribeWithToken').mockResolvedValue({ resultStatus: 'unsubscribed' });
+    renderWithToken('valid-token');
+
+    fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.unsubscribeSuccessTitle.defaultMessage)).toBeInTheDocument();
+    });
+    expect(spy).toHaveBeenCalledWith('valid-token');
+  });
+
+  test('shows error state and allows retry on failure', async () => {
+    const spy = jest.spyOn(api, 'unsubscribeWithToken').mockRejectedValue(new Error('boom'));
+    renderWithToken('valid-token');
+
+    fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.unsubscribeErrorTitle.defaultMessage)).toBeInTheDocument();
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Retry button should re-trigger the request
+    spy.mockResolvedValueOnce({ resultStatus: 'unsubscribed' });
+    fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeRetry.defaultMessage }));
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.unsubscribeSuccessTitle.defaultMessage)).toBeInTheDocument();
+    });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
@@ -7,30 +7,13 @@ import ReleaseNoteUnsubscribe from './ReleaseNoteUnsubscribe';
 import messages from './messages';
 import * as api from '../data/api';
 
-const renderWithToken = (token) => {
-  const initialEntries = token === undefined
-    ? ['/release-notes/unsubscribe']
-    : [`/release-notes/unsubscribe?token=${encodeURIComponent(token)}`];
-  return render(<ReleaseNoteUnsubscribe />, {
-    routerProps: { initialEntries },
-  });
-};
-
 describe('ReleaseNoteUnsubscribe', () => {
   beforeEach(() => {
     initializeMocks();
   });
 
-  test('shows error alert when no token is present', () => {
-    renderWithToken(undefined);
-    expect(screen.getByText(messages.unsubscribeError.defaultMessage)).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: messages.unsubscribeButton.defaultMessage }),
-    ).not.toBeInTheDocument();
-  });
-
-  test('renders the idle confirmation state when a token is present', () => {
-    renderWithToken('valid-token');
+  test('renders the idle confirmation state', () => {
+    render(<ReleaseNoteUnsubscribe />);
     expect(screen.getByText(messages.unsubscribeTitle.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.unsubscribeConfirmation.defaultMessage)).toBeInTheDocument();
     expect(
@@ -40,19 +23,19 @@ describe('ReleaseNoteUnsubscribe', () => {
 
   test('calls unsubscribeFromReleaseNoteEmails and shows success state on success', async () => {
     const spy = jest.spyOn(api, 'unsubscribeFromReleaseNoteEmails').mockResolvedValue({ message: 'ok' });
-    renderWithToken('valid-token');
+    render(<ReleaseNoteUnsubscribe />);
 
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
 
     await waitFor(() => {
       expect(screen.getByText(messages.unsubscribeSuccessTitle.defaultMessage)).toBeInTheDocument();
     });
-    expect(spy).toHaveBeenCalledWith('valid-token');
+    expect(spy).toHaveBeenCalledWith();
   });
 
   test('shows error state and allows retry on failure', async () => {
     const spy = jest.spyOn(api, 'unsubscribeFromReleaseNoteEmails').mockRejectedValue(new Error('boom'));
-    renderWithToken('valid-token');
+    render(<ReleaseNoteUnsubscribe />);
 
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
 

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
@@ -24,7 +24,6 @@ describe('ReleaseNoteUnsubscribe', () => {
   test('shows error alert when no token is present', () => {
     renderWithToken(undefined);
     expect(screen.getByText(messages.unsubscribeError.defaultMessage)).toBeInTheDocument();
-    // The confirmation CTA should not be rendered without a token
     expect(
       screen.queryByRole('button', { name: messages.unsubscribeButton.defaultMessage }),
     ).not.toBeInTheDocument();
@@ -39,8 +38,8 @@ describe('ReleaseNoteUnsubscribe', () => {
     ).toBeInTheDocument();
   });
 
-  test('calls unsubscribeWithToken and shows success state on success', async () => {
-    const spy = jest.spyOn(api, 'unsubscribeWithToken').mockResolvedValue({ resultStatus: 'unsubscribed' });
+  test('calls unsubscribeFromReleaseNoteEmails and shows success state on success', async () => {
+    const spy = jest.spyOn(api, 'unsubscribeFromReleaseNoteEmails').mockResolvedValue({ message: 'ok' });
     renderWithToken('valid-token');
 
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
@@ -52,7 +51,7 @@ describe('ReleaseNoteUnsubscribe', () => {
   });
 
   test('shows error state and allows retry on failure', async () => {
-    const spy = jest.spyOn(api, 'unsubscribeWithToken').mockRejectedValue(new Error('boom'));
+    const spy = jest.spyOn(api, 'unsubscribeFromReleaseNoteEmails').mockRejectedValue(new Error('boom'));
     renderWithToken('valid-token');
 
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
@@ -62,8 +61,7 @@ describe('ReleaseNoteUnsubscribe', () => {
     });
     expect(spy).toHaveBeenCalledTimes(1);
 
-    // Retry button should re-trigger the request
-    spy.mockResolvedValueOnce({ resultStatus: 'unsubscribed' });
+    spy.mockResolvedValueOnce({ message: 'ok' });
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeRetry.defaultMessage }));
 
     await waitFor(() => {

--- a/src/release-notes/unsubscribe/messages.js
+++ b/src/release-notes/unsubscribe/messages.js
@@ -35,7 +35,7 @@ const messages = defineMessages({
   },
   unsubscribeError: {
     id: 'release-notes.unsubscribe.error',
-    defaultMessage: 'We were unable to process your unsubscribe request. The link may have expired or is invalid. Please sign in with the account that received the email and try again.',
+    defaultMessage: 'We were unable to process your unsubscribe request. Please sign in with the account that received the email and try again.',
   },
   unsubscribeRetry: {
     id: 'release-notes.unsubscribe.retry',

--- a/src/release-notes/unsubscribe/messages.js
+++ b/src/release-notes/unsubscribe/messages.js
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  unsubscribeTitle: {
+    id: 'release-notes.unsubscribe.title',
+    defaultMessage: 'Unsubscribe from Release Notes',
+  },
+  unsubscribeConfirmation: {
+    id: 'release-notes.unsubscribe.confirmation',
+    defaultMessage: 'You will no longer receive email notifications when new edX.org Release Notes are published.',
+  },
+  unsubscribeButton: {
+    id: 'release-notes.unsubscribe.button',
+    defaultMessage: 'Unsubscribe',
+  },
+  unsubscribeDisclaimer: {
+    id: 'release-notes.unsubscribe.disclaimer',
+    defaultMessage: 'This only affects Release Notes emails. You will continue to receive other important account notifications.',
+  },
+  unsubscribeProcessing: {
+    id: 'release-notes.unsubscribe.processing',
+    defaultMessage: 'Processing your request...',
+  },
+  unsubscribeSuccessTitle: {
+    id: 'release-notes.unsubscribe.success.title',
+    defaultMessage: 'Successfully Unsubscribed',
+  },
+  unsubscribeSuccess: {
+    id: 'release-notes.unsubscribe.success',
+    defaultMessage: 'You have been successfully unsubscribed from future Release Notes announcements. You will no longer receive these emails.',
+  },
+  unsubscribeErrorTitle: {
+    id: 'release-notes.unsubscribe.error.title',
+    defaultMessage: 'Something Went Wrong',
+  },
+  unsubscribeError: {
+    id: 'release-notes.unsubscribe.error',
+    defaultMessage: 'We were unable to process your unsubscribe request. The link may have expired or is invalid.',
+  },
+  unsubscribeRetry: {
+    id: 'release-notes.unsubscribe.retry',
+    defaultMessage: 'Try Again',
+  },
+});
+
+export default messages;

--- a/src/release-notes/unsubscribe/messages.js
+++ b/src/release-notes/unsubscribe/messages.js
@@ -35,7 +35,7 @@ const messages = defineMessages({
   },
   unsubscribeError: {
     id: 'release-notes.unsubscribe.error',
-    defaultMessage: 'We were unable to process your unsubscribe request. The link may have expired or is invalid.',
+    defaultMessage: 'We were unable to process your unsubscribe request. The link may have expired or is invalid. Please sign in with the account that received the email and try again.',
   },
   unsubscribeRetry: {
     id: 'release-notes.unsubscribe.retry',

--- a/src/release-notes/update-form/ReleaseNoteForm.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.jsx
@@ -172,6 +172,8 @@ const ReleaseNoteForm = ({
     const initialDesc = normalizeHtml(initialVals.description);
     if (currentDesc !== initialDesc) { return true; }
 
+    if (values.sendEmail !== initialVals.sendEmail) { return true; }
+
     return false;
   }, []);
 
@@ -187,6 +189,7 @@ const ReleaseNoteForm = ({
         publishTime: initialValues.published_at
           ? moment(initialValues.published_at).format(TIME_FORMAT)
           : '',
+        sendEmail: false,
       };
       const customDirty = isFormDirty(currentValuesRef.current, formInitialValues);
       isDirtyRef.current = customDirty;

--- a/src/release-notes/update-form/ReleaseNoteForm.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.jsx
@@ -379,6 +379,7 @@ ReleaseNoteForm.propTypes = {
     title: PropTypes.string,
     description: PropTypes.string,
     published_at: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    sendEmail: PropTypes.bool,
   }).isRequired,
   close: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/src/release-notes/update-form/ReleaseNoteForm.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.jsx
@@ -189,7 +189,7 @@ const ReleaseNoteForm = ({
         publishTime: initialValues.published_at
           ? moment(initialValues.published_at).format(TIME_FORMAT)
           : '',
-        sendEmail: false,
+        sendEmail: Boolean(initialValues.sendEmail),
       };
       const customDirty = isFormDirty(currentValuesRef.current, formInitialValues);
       isDirtyRef.current = customDirty;
@@ -209,7 +209,7 @@ const ReleaseNoteForm = ({
           description: initialValues.description || '',
           publishDate: initialValues.published_at ? moment(convertToDateFromString(initialValues.published_at)).format('YYYY-MM-DD') : '',
           publishTime: initialValues.published_at ? moment(initialValues.published_at).format(TIME_FORMAT) : '',
-          sendEmail: false,
+          sendEmail: Boolean(initialValues.sendEmail),
         }}
         validationSchema={validationSchema}
         validateOnMount

--- a/src/release-notes/update-form/ReleaseNoteForm.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.jsx
@@ -25,6 +25,7 @@ const ReleaseNoteForm = ({
   initialValues,
   close,
   onSubmit,
+  canSendReleaseNoteEmails,
   savingStatuses,
   isDirtyCheckRef,
   showUnsavedModalRef,
@@ -205,6 +206,7 @@ const ReleaseNoteForm = ({
           description: initialValues.description || '',
           publishDate: initialValues.published_at ? moment(convertToDateFromString(initialValues.published_at)).format('YYYY-MM-DD') : '',
           publishTime: initialValues.published_at ? moment(initialValues.published_at).format(TIME_FORMAT) : '',
+          sendEmail: false,
         }}
         validationSchema={validationSchema}
         validateOnMount
@@ -222,6 +224,7 @@ const ReleaseNoteForm = ({
             title: values.title,
             description: values.description,
             published_at: composed,
+            sendEmail: values.sendEmail,
           };
           onSubmit(payload);
         }}
@@ -332,6 +335,21 @@ const ReleaseNoteForm = ({
                 )}
               </Form.Group>
 
+              {canSendReleaseNoteEmails && (
+                <Form.Group className="mb-3">
+                  <Form.Checkbox
+                    checked={values.sendEmail || false}
+                    onChange={(e) => setFieldValue('sendEmail', e.target.checked)}
+                    data-testid="send-email-checkbox"
+                  >
+                    {intl.formatMessage(messages.sendEmailCheckboxLabel)}
+                  </Form.Checkbox>
+                  <Form.Text muted>
+                    {intl.formatMessage(messages.sendEmailCheckboxHelp)}
+                  </Form.Text>
+                </Form.Group>
+              )}
+
               <ActionRow>
                 <Button variant="tertiary" type="button" onClick={(e) => handleCancel(e, dirty)}>
                   {intl.formatMessage(messages.cancelButton)}
@@ -361,6 +379,7 @@ ReleaseNoteForm.propTypes = {
   }).isRequired,
   close: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  canSendReleaseNoteEmails: PropTypes.bool,
   savingStatuses: PropTypes.shape({
     createReleaseNoteQuery: PropTypes.string,
     editReleaseNoteQuery: PropTypes.string,
@@ -372,6 +391,7 @@ ReleaseNoteForm.propTypes = {
 };
 
 ReleaseNoteForm.defaultProps = {
+  canSendReleaseNoteEmails: false,
   savingStatuses: {},
   isDirtyCheckRef: null,
   showUnsavedModalRef: null,

--- a/src/release-notes/update-form/ReleaseNoteForm.test.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.test.jsx
@@ -321,6 +321,23 @@ describe('ReleaseNoteForm', () => {
       expect(checkbox).toBeChecked();
     });
 
+    test('marks form dirty when send email checkbox is toggled', async () => {
+      const isDirtyCheckRef = { current: null };
+      renderForm({ isDirtyCheckRef, canSendReleaseNoteEmails: true });
+
+      await waitFor(() => {
+        expect(isDirtyCheckRef.current).toBeInstanceOf(Function);
+      });
+
+      expect(isDirtyCheckRef.current()).toBe(false);
+
+      fireEvent.click(screen.getByTestId('send-email-checkbox'));
+
+      await waitFor(() => {
+        expect(isDirtyCheckRef.current()).toBe(true);
+      });
+    });
+
     test('includes sendEmail=true in onSubmit payload when checked', async () => {
       const onSubmit = jest.fn();
       renderForm({

--- a/src/release-notes/update-form/ReleaseNoteForm.test.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.test.jsx
@@ -314,6 +314,17 @@ describe('ReleaseNoteForm', () => {
       expect(screen.getByText(messages.sendEmailCheckboxHelp.defaultMessage)).toBeInTheDocument();
     });
 
+    test('renders the send-email checkbox checked when editing a note with sendEmail enabled', () => {
+      renderForm({
+        canSendReleaseNoteEmails: true,
+        initialValues: {
+          ...mockFormFilledValues,
+          sendEmail: true,
+        },
+      });
+      expect(screen.getByTestId('send-email-checkbox')).toBeChecked();
+    });
+
     test('toggles the checkbox on click', () => {
       renderForm({ canSendReleaseNoteEmails: true });
       const checkbox = screen.getByTestId('send-email-checkbox');

--- a/src/release-notes/update-form/ReleaseNoteForm.test.jsx
+++ b/src/release-notes/update-form/ReleaseNoteForm.test.jsx
@@ -300,6 +300,83 @@ describe('ReleaseNoteForm', () => {
     });
   });
 
+  describe('Send email notification checkbox', () => {
+    test('does not render the send-email checkbox when canSendReleaseNoteEmails is false', () => {
+      renderForm({ canSendReleaseNoteEmails: false });
+      expect(screen.queryByTestId('send-email-checkbox')).not.toBeInTheDocument();
+    });
+
+    test('renders the send-email checkbox unchecked by default', () => {
+      renderForm({ canSendReleaseNoteEmails: true });
+      const checkbox = screen.getByTestId('send-email-checkbox');
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).not.toBeChecked();
+      expect(screen.getByText(messages.sendEmailCheckboxHelp.defaultMessage)).toBeInTheDocument();
+    });
+
+    test('toggles the checkbox on click', () => {
+      renderForm({ canSendReleaseNoteEmails: true });
+      const checkbox = screen.getByTestId('send-email-checkbox');
+      fireEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
+    });
+
+    test('includes sendEmail=true in onSubmit payload when checked', async () => {
+      const onSubmit = jest.fn();
+      renderForm({
+        canSendReleaseNoteEmails: true,
+        onSubmit,
+        initialValues: {
+          ...mockFormInitialValues,
+          title: 'Test',
+          description: '<p>Test</p>',
+        },
+      });
+
+      fireEvent.change(screen.getByLabelText(messages.publishDateLabel.defaultMessage), {
+        target: { value: '2025-01-20' },
+      });
+      fireEvent.change(screen.getByLabelText(/publish time/i), {
+        target: { value: '14:30' },
+      });
+      fireEvent.click(screen.getByTestId('send-email-checkbox'));
+
+      fireEvent.click(screen.getByRole('button', { name: messages.saveButton.defaultMessage }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+        expect(onSubmit.mock.calls[0][0].sendEmail).toBe(true);
+      });
+    });
+
+    test('includes sendEmail=false in onSubmit payload when left unchecked', async () => {
+      const onSubmit = jest.fn();
+      renderForm({
+        canSendReleaseNoteEmails: true,
+        onSubmit,
+        initialValues: {
+          ...mockFormInitialValues,
+          title: 'Test',
+          description: '<p>Test</p>',
+        },
+      });
+
+      fireEvent.change(screen.getByLabelText(messages.publishDateLabel.defaultMessage), {
+        target: { value: '2025-01-20' },
+      });
+      fireEvent.change(screen.getByLabelText(/publish time/i), {
+        target: { value: '14:30' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: messages.saveButton.defaultMessage }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+        expect(onSubmit.mock.calls[0][0].sendEmail).toBe(false);
+      });
+    });
+  });
+
   describe('onInterceptClose', () => {
     test('does not error when onInterceptClose is not provided', () => {
       expect(() => renderForm()).not.toThrow();


### PR DESCRIPTION
Adds opt-in email notification support to the Release Notes publish flow. When a user with the appropriate permission publishes or edits a release note, they can now opt in to send an email notification to all course authors on the platform. This PR also introduces a token-based unsubscribe flow, allowing recipients to unsubscribe from future release note emails via a dedicated page.

---

### Changes

#### Feature: Send Email on Publish

- Added a `sendEmail` Formik field (default: `false`) to `ReleaseNoteForm` with a permission-gated checkbox (`canSendReleaseNoteEmails`).
- The checkbox is labelled "Send email notification to all course authors" with supporting help text explaining its effect.
- On submit (both create and edit), `sendEmail` is extracted from form data, stripped from the note payload, and remapped to `send_email_on_publish` before being sent to the API. Defaults to `false` when absent.

#### Data Layer: `canSendReleaseNoteEmails` Capability

- The `fetchReleaseNotesQuery` thunk now reads `canSendReleaseNoteEmails` from the API response and includes it in the `fetchReleaseNotesSuccess` dispatch payload.
- Redux slice (`slice.js`) initializes `canSendReleaseNoteEmails: false` and stores it on fetch success.
- New selector `getCanSendReleaseNoteEmails` added to `selectors.js`.
- `useReleaseNotes` hook updated to expose `canSendReleaseNoteEmails` via `useSelector`, and it is passed down through `ReleaseNotes.jsx` into `ReleaseNoteForm`.

#### Feature: Unsubscribe Page

- New `ReleaseNoteUnsubscribe` component at `src/release-notes/unsubscribe/` implementing a 4-state UI: `idle` → `loading` → `success` / `error`.
- Token is read from the `?token=` query param. If absent, an error alert is shown immediately without rendering the confirmation card.
- On confirmation, calls `unsubscribeFromReleaseNoteEmails(token)` (new API helper) which issues an authenticated GET to `/api/release_notes/v1/email/unsubscribe/?token=<encoded>`.
- Error state includes a retry button (`outline-primary`).
- New route `/release-notes/unsubscribe` registered in `src/index.jsx` — intentionally outside the `ENABLE_RELEASE_NOTES` feature flag gate so unsubscribe links remain functional for all users regardless of flag state.
- New i18n message keys added in `unsubscribe/messages.js`: title, confirmation prompt, button label, disclaimer, processing text, success heading/body, error heading/body, retry label.

#### API

- New URL helper `getUnsubscribeApiUrl()` pointing to `/api/release_notes/v1/email/unsubscribe/`.
- New exported function `unsubscribeFromReleaseNoteEmails(token)` — makes an authenticated GET with the token URL-encoded, returns a camelCased response object.

---

### Notes

- The unsubscribe route is **not** wrapped in the `ENABLE_RELEASE_NOTES` config gate, by design — email recipients need to be able to reach the unsubscribe page even if the release notes feature is toggled off for their instance.
- `sendEmail` defaults to `false` on form initialization; it is a one-time flag per publish action and is not persisted back to the form on re-open. 


---

## Support ticket
- [TNL2-584](https://2u-internal.atlassian.net/browse/TNL2-584)
- [LP-815](https://2u-internal.atlassian.net/browse/LP-815)
