### PR TITLE
feat(course-outline): add unit title link in expanded outline view

### DIFF
--- a/src/course-outline/card-header/CardHeader.scss
+++ b/src/course-outline/card-header/CardHeader.scss
@@ -22,6 +22,52 @@
       text-align: left;
       -webkit-box-orient: vertical;  /* stylelint-disable-line value-no-vendor-prefix */
     }
+
+    &--with-link {
+      &:hover,
+      &:focus-within {
+        background-color: var(--pgn-color-light-300);
+      }
+
+      .item-card-header__title-expand-btn {
+        inset: 0;
+        min-height: unset;
+        box-shadow: none;
+
+        &:hover,
+        &:focus,
+        &:active {
+          background: transparent;
+          box-shadow: none;
+        }
+
+        &:focus-visible {
+          outline: .125rem solid var(--pgn-color-primary-500);
+          outline-offset: .125rem;
+        }
+      }
+
+      > .pgn__icon {
+        pointer-events: none;
+      }
+
+      .item-card-header__title-link-content .truncate-1-line {
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+        -webkit-line-clamp: unset;
+        line-clamp: unset;
+        -webkit-box-orient: unset;
+      }
+
+      .item-card-header__title-link-content:hover .truncate-1-line {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 3px;
+      }
+    }
   }
 
   .item-card-button-icon {

--- a/src/course-outline/card-header/CardHeader.scss
+++ b/src/course-outline/card-header/CardHeader.scss
@@ -24,6 +24,8 @@
     }
 
     &--with-link {
+      margin-top: 0.625rem;
+
       &:hover,
       &:focus-within {
         background-color: var(--pgn-color-light-300);

--- a/src/course-outline/card-header/CardHeader.tsx
+++ b/src/course-outline/card-header/CardHeader.tsx
@@ -11,6 +11,7 @@ import {
   Icon,
   IconButton,
   IconButtonWithTooltip,
+  Stack,
   useToggle,
 } from '@openedx/paragon';
 import {
@@ -180,7 +181,12 @@ const CardHeader = ({
             />
           </Form.Group>
         ) : (
-          <>
+          <Stack
+            direction="horizontal"
+            gap={0}
+            className="component-title-group flex-grow-1 min-width-0 align-items-center"
+            role="presentation"
+          >
             {titleComponent}
             <IconButtonWithTooltip
               className="item-card-button-icon"
@@ -192,7 +198,7 @@ const CardHeader = ({
               // @ts-ignore
               disabled={isSaving}
             />
-          </>
+          </Stack>
         )}
         <div className="ml-auto d-flex">
           {(isVertical || isSequential) && (

--- a/src/course-outline/card-header/TitleButton.tsx
+++ b/src/course-outline/card-header/TitleButton.tsx
@@ -1,7 +1,11 @@
+import { Link } from 'react-router-dom';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button,
+  Hyperlink,
+  Icon,
   OverlayTrigger,
+  Stack,
   Tooltip,
 } from '@openedx/paragon';
 import {
@@ -16,6 +20,7 @@ interface TitleButtonProps {
   isExpanded: boolean;
   onTitleClick: () => void;
   namePrefix: string;
+  titleLink?: string;
 }
 
 const TitleButton = ({
@@ -24,9 +29,93 @@ const TitleButton = ({
   isExpanded,
   onTitleClick,
   namePrefix,
+  titleLink,
 }: TitleButtonProps) => {
   const intl = useIntl();
   const titleTooltipMessage = intl.formatMessage(messages.expandTooltip);
+  const ExpandIcon = isExpanded ? ArrowDownIcon : ArrowRightIcon;
+  const titleText = (
+    <span className={`${namePrefix}-card-title mb-0 truncate-1-line`}>
+      {title}
+    </span>
+  );
+
+  const handleExpandClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onTitleClick();
+  };
+
+  const stopTitleLinkPropagation = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  const isExternalTitleLink = !!titleLink && /^[a-z][a-z\d+\-.]*:/i.test(titleLink);
+
+  const titleLinkClassName = 'item-card-header__title-link-content min-width-0 flex-shrink-1 position-relative zindex-2 d-inline-flex align-items-center text-decoration-none';
+
+  const linkedTitle = titleLink && (
+    isExternalTitleLink ? (
+      <Hyperlink
+        className={titleLinkClassName}
+        data-testid={`${namePrefix}-card-header__title-link`}
+        destination={titleLink}
+        isInline
+        showLaunchIcon={false}
+        onClick={stopTitleLinkPropagation}
+        onMouseDown={stopTitleLinkPropagation}
+      >
+        {titleText}
+      </Hyperlink>
+    ) : (
+      <Button
+        as={Link}
+        variant="tertiary"
+        className={titleLinkClassName}
+        data-testid={`${namePrefix}-card-header__title-link`}
+        to={titleLink}
+        onClick={stopTitleLinkPropagation}
+        onMouseDown={stopTitleLinkPropagation}
+      >
+        {titleText}
+      </Button>
+    )
+  );
+
+  if (titleLink) {
+    return (
+      <OverlayTrigger
+        placement="bottom"
+        overlay={(
+          <Tooltip id={`${title}-${titleTooltipMessage}`}>
+            {titleTooltipMessage}
+          </Tooltip>
+        )}
+      >
+        <Stack
+          direction="horizontal"
+          className="item-card-header__title-btn item-card-header__title-btn--with-link align-items-center position-relative rounded-pill"
+        >
+          <Button
+            type="button"
+            variant="tertiary"
+            className="item-card-header__title-expand-btn position-absolute w-100 h-100 p-0 border-0 bg-transparent"
+            data-testid={`${namePrefix}-card-header__expanded-btn`}
+            aria-expanded={isExpanded}
+            aria-label={titleTooltipMessage}
+            onClick={handleExpandClick}
+          >
+            <span className="sr-only">{titleTooltipMessage}</span>
+          </Button>
+          <Icon
+            src={ExpandIcon}
+            className="flex-shrink-0 mr-1 position-relative zindex-1"
+          />
+          {prefixIcon}
+          {linkedTitle}
+        </Stack>
+      </OverlayTrigger>
+    );
+  }
 
   return (
     <OverlayTrigger
@@ -40,7 +129,7 @@ const TitleButton = ({
       )}
     >
       <Button
-        iconBefore={isExpanded ? ArrowDownIcon : ArrowRightIcon}
+        iconBefore={ExpandIcon}
         variant="tertiary"
         data-testid={`${namePrefix}-card-header__expanded-btn`}
         className="item-card-header__title-btn"
@@ -48,9 +137,7 @@ const TitleButton = ({
         title={title}
       >
         {prefixIcon}
-        <span className={`${namePrefix}-card-title mb-0 truncate-1-line`}>
-          {title}
-        </span>
+        {titleText}
       </Button>
     </OverlayTrigger>
   );

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -329,6 +329,41 @@ describe('<UnitCard />', () => {
     expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
   });
 
+  it('renders the unit title as a link when expanded outline view is enabled', async () => {
+    renderComponent();
+
+    const titleLink = await screen.findByTestId('unit-card-header__title-link');
+    expect(titleLink).toHaveAttribute('href', `/some/${unit.id}`);
+    expect(titleLink).toHaveTextContent(unit.displayName);
+  });
+
+  it('does not expand the unit card when the title link is clicked', async () => {
+    renderComponent();
+
+    const titleLink = await screen.findByTestId('unit-card-header__title-link');
+    titleLink.addEventListener('click', (event) => event.preventDefault());
+
+    fireEvent.click(titleLink);
+
+    expect(screen.queryByTestId('unit-card__components')).not.toBeInTheDocument();
+  });
+
+  it('expands the unit card when the non-title expand area is clicked', async () => {
+    mockUseUnitHandler.mockReturnValue({
+      data: { components: [] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    renderComponent();
+
+    const expandButton = await screen.findByTestId('unit-card-header__expanded-btn');
+    fireEvent.click(expandButton);
+
+    expect(await screen.findByTestId('unit-card__components')).toBeInTheDocument();
+  });
+
   describe('component editor links', () => {
     const htmlComponent = {
       blockId: 'block-v1:test+type@html+block@1',

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -407,6 +407,7 @@ const UnitCard = ({
       onTitleClick={handleExpandContent}
       namePrefix={namePrefix}
       prefixIcon={<UpstreamInfoIcon upstreamInfo={upstreamInfo} size="sm" />}
+      titleLink={getTitleLink(id)}
     />
   ) : (
     <TitleLink


### PR DESCRIPTION
- Updated TitleButton to support external and internal links, allowing the title to be clickable.
- Added hover and focus styles for linked titles in CardHeader.scss.
- Implemented tests to verify link rendering and interaction behavior in UnitCard.
- Ensured that clicking the title link does not expand the unit card, while the expand button still functions as intended.
---

## Description

This PR makes the unit title clickable in the expanded Course Outline view in Studio, allowing Course Authors to navigate directly to a unit without first expanding it.

`TitleButton` now accepts an optional `titleLink` prop:

- When `titleLink` is **not** provided, the button renders exactly as before — clicking anywhere on it toggles expand/collapse.
- When `titleLink` **is** provided:
  - The title text renders as a link — `Hyperlink` for absolute/external URLs, or a `react-router-dom`-backed `Button` (`as={Link}`) for internal routes — determined by a new `isExternalTitleLink` check (`/^[a-z][a-z\d+\-.]*:/i`).
  - A separate expand/collapse `Button` is overlaid across the full row (`position-absolute`, `w-100 h-100`, transparent background), so clicking anywhere except the title link toggles the unit's expanded state, while clicking the title navigates to the unit.
  - Both render paths now share a single `ExpandIcon` variable (previously an inline `isExpanded ? ArrowDownIcon : ArrowRightIcon` ternary) and a shared `titleText` element.

New `--with-link` modifier styles in `CardHeader.scss`:

- Highlights the row background on hover/`focus-within`.
- Underlines the title text on hover.
- Adds a `:focus-visible` outline on the expand control for keyboard users.
- Ensures the `pgn__icon` doesn't intercept pointer events, and fixes truncation (`truncate-1-line`) for the linked title content.

`UnitCard.tsx` passes `titleLink={getTitleLink(id)}` to `TitleButton`, wiring this new behavior into unit cards in the expanded outline view.

**User roles impacted:** Course Author (Studio – Course Outline page).

## Supporting information
- Ticket: LP-249

## Testing instructions

1. Pull this branch and run Studio.
2. Open a course's **Course Outline** page and switch to the expanded outline view.
3. Expand a section/subsection so unit cards are visible.
4. Hover over a unit's title — the row background should highlight and the title text should underline.
5. Click the unit's title text:
   - You should navigate to that unit.
   - The unit card should **not** expand to show its components.
6. Click elsewhere on the unit row (the expand/chevron area):
   - The unit card should expand/collapse as before.
7. Tab to the row with the keyboard and confirm a visible focus outline appears on the expand control.
8. Run:
   ```
   jest src/course-outline/unit-card/UnitCard.test.tsx
   ```
   and confirm the three new tests pass:
   - renders the unit title as a link when expanded outline view is enabled
   - does not expand the unit card when the title link is clicked
   - expands the unit card when the non-title expand area is clicked

## Other information

- No backend/API changes — `getTitleLink(id)` already existed; this PR wires it into `TitleButton`.
- No new dependencies — `Hyperlink`, `OverlayTrigger`, `Stack`, and `Tooltip` are existing `@openedx/paragon` components already used elsewhere in this codebase.
- Accessibility: avoids nesting an interactive link inside an interactive button by overlaying the expand button *behind* the title link and stopping click/mousedown propagation on the link, so the two controls don't conflict. Added `:focus-visible` styling on the expand control.
- This PR targets `release-ulmo` rather than the default branch — double-check whether it also needs to land on the main development branch.

## Best Practices Checklist

- [x] Any *new* files are using TypeScript (`.ts`, `.tsx`) — N/A, no new files added.
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests use the helpers in `src/testUtils.tsx` (`initializeMocks`).
- [x] No new fields added to the Redux state/store.
- [x] Use React Query to load data from REST APIs — N/A, no new API calls in this PR.
- [x] All new i18n messages have a `description` for translators — N/A, no new i18n messages added.
- [x] Imports avoid using `../`.