### PR TITLE
feat(inVideoQuiz): allow multiple in-video quiz problems at the same timestamp

### DIFF
--- a/src/editors/containers/InVideoQuizEditor/index.jsx
+++ b/src/editors/containers/InVideoQuizEditor/index.jsx
@@ -106,14 +106,6 @@ export const InVideoQuizEditor = ({
       setSaveError(intl.formatMessage(messages.timeFormatError));
       return;
     }
-    const times = quizItems
-      .map((item) => item.time)
-      .filter(Boolean);
-    const hasDuplicateTimes = times.length !== new Set(times).size;
-    if (hasDuplicateTimes) {
-      setSaveError(intl.formatMessage(messages.duplicateTimeError));
-      return;
-    }
     const hasProblemWithoutTimer = quizItems.some((item) => item.problemId && !item.time);
     if (hasProblemWithoutTimer) {
       setSaveError(intl.formatMessage(messages.timerRequiredError));

--- a/src/editors/containers/InVideoQuizEditor/index.jsx
+++ b/src/editors/containers/InVideoQuizEditor/index.jsx
@@ -49,6 +49,7 @@ export const InVideoQuizEditor = ({
   videos,
   problems,
   quizItems,
+  unitContentLoaded,
   setSelectedVideo,
   addQuizItem,
   removeQuizItem,
@@ -60,14 +61,14 @@ export const InVideoQuizEditor = ({
   isDirty,
 }) => {
   const intl = useIntl();
-  const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [saveError, setSaveError] = useState(null);
   const [contentAlertDismissed, setContentAlertDismissed] = useState(false);
   const returnUrl = useSelector(selectors.app.returnUrl);
   const analytics = useSelector(selectors.app.analytics);
 
-  const hasNoVideos = blockFinished && settingsLoaded && videos.length === 0;
-  const hasNoProblems = blockFinished && settingsLoaded && problems.length === 0;
+  const hasNoVideos = unitContentLoaded && videos.length === 0;
+  const hasNoProblems = unitContentLoaded && problems.length === 0;
+  const isLoadingUnitContent = blockFinished && blockId && blockValue && !unitContentLoaded;
 
   const isValidTimeFormat = useCallback((value) => /^\d+:[0-5]\d$/.test(value), []);
 
@@ -90,11 +91,10 @@ export const InVideoQuizEditor = ({
   }, [isValidTimeFormat]);
 
   useEffect(() => {
-    if (blockFinished && blockId && blockValue && !settingsLoaded) {
+    if (blockFinished && blockId && blockValue && !unitContentLoaded) {
       loadInVideoQuizSettings();
-      setSettingsLoaded(true);
     }
-  }, [blockFinished, blockId, blockValue, settingsLoaded, loadInVideoQuizSettings]);
+  }, [blockFinished, blockId, blockValue, unitContentLoaded, loadInVideoQuizSettings]);
 
   const handleSave = useCallback(() => {
     setSaveError(null);
@@ -359,7 +359,7 @@ export const InVideoQuizEditor = ({
       saveButtonAriaLabel={intl.formatMessage(messages.save)}
     >
       <div className="editor-body h-75 overflow-auto">
-        {!blockFinished ? loading : page}
+        {!blockFinished || isLoadingUnitContent ? loading : page}
       </div>
     </EditorContainer>
   );
@@ -387,6 +387,7 @@ InVideoQuizEditor.propTypes = {
     time: PropTypes.string,
     jumpBack: PropTypes.string,
   })),
+  unitContentLoaded: PropTypes.bool.isRequired,
   setSelectedVideo: PropTypes.func.isRequired,
   addQuizItem: PropTypes.func.isRequired,
   removeQuizItem: PropTypes.func.isRequired,
@@ -416,6 +417,7 @@ export const mapStateToProps = (state) => ({
   problems: selectors.inVideoQuiz.problems(state),
   quizItems: selectors.inVideoQuiz.quizItems(state),
   isDirty: selectors.inVideoQuiz.isDirty(state),
+  unitContentLoaded: selectors.inVideoQuiz.unitContentLoaded(state),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/InVideoQuizEditor/index.test.jsx
+++ b/src/editors/containers/InVideoQuizEditor/index.test.jsx
@@ -307,6 +307,39 @@ describe('InVideoQuizEditor', () => {
 
       expect(thunkActions.inVideoQuiz.loadInVideoQuizSettings).toHaveBeenCalled();
     });
+
+    it('allows saving when multiple problems share the same timestamp', () => {
+      editorRender(
+        <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
+        {
+          initialState: {
+            ...baseState,
+            inVideoQuiz: {
+              ...baseState.inVideoQuiz,
+              selectedVideo: 'video-1',
+              videos: [{ id: 'video-1', display_name: 'Video 1' }],
+              problems: [
+                { id: 'problem-1', display_name: 'Problem 1' },
+                { id: 'problem-2', display_name: 'Problem 2' },
+              ],
+              quizItems: [
+                {
+                  id: 'quiz-1', problemId: 'problem-1', time: '1:30', jumpBack: '',
+                },
+                {
+                  id: 'quiz-2', problemId: 'problem-2', time: '1:30', jumpBack: '',
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      fireEvent.click(screen.getByTestId('save-button'));
+
+      expect(screen.queryByText('Each problem must have a unique timestamp. Please remove duplicate times.')).not.toBeInTheDocument();
+      expect(thunkActions.inVideoQuiz.saveInVideoQuizSettings).toHaveBeenCalled();
+    });
   });
 
   describe('hooks.getContent', () => {

--- a/src/editors/containers/InVideoQuizEditor/index.test.jsx
+++ b/src/editors/containers/InVideoQuizEditor/index.test.jsx
@@ -74,6 +74,7 @@ const baseState = {
     selectedVideo: null,
     videos: [],
     problems: [],
+    unitContentLoaded: false,
     quizItems: [
       {
         id: 'quiz-1', problemId: '', time: '', jumpBack: '',
@@ -92,7 +93,15 @@ describe('InVideoQuizEditor', () => {
     it('shows both alerts when no videos and no problems exist in the unit', () => {
       editorRender(
         <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
-        { initialState: baseState },
+        {
+          initialState: {
+            ...baseState,
+            inVideoQuiz: {
+              ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
+            },
+          },
+        },
       );
 
       expect(screen.getByText('Content not found')).toBeInTheDocument();
@@ -108,6 +117,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               problems: [{ id: 'problem-1', display_name: 'Problem 1' }],
             },
           },
@@ -127,6 +137,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               videos: [{ id: 'video-1', display_name: 'Video 1' }],
             },
           },
@@ -146,6 +157,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               videos: [{ id: 'video-1', display_name: 'Video 1' }],
               problems: [{ id: 'problem-1', display_name: 'Problem 1' }],
             },
@@ -161,14 +173,7 @@ describe('InVideoQuizEditor', () => {
     it('does not show alert while still loading', () => {
       editorRender(
         <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
-        {
-          initialState: {
-            ...baseState,
-            requests: {
-              fetchBlock: { status: 'pending' },
-            },
-          },
-        },
+        { initialState: baseState },
       );
 
       expect(screen.queryByText('Content not found')).not.toBeInTheDocument();
@@ -179,7 +184,15 @@ describe('InVideoQuizEditor', () => {
     it('dismisses the alert when close button is clicked', () => {
       editorRender(
         <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
-        { initialState: baseState },
+        {
+          initialState: {
+            ...baseState,
+            inVideoQuiz: {
+              ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
+            },
+          },
+        },
       );
 
       expect(screen.getByText('Content not found')).toBeInTheDocument();
@@ -211,6 +224,17 @@ describe('InVideoQuizEditor', () => {
       expect(container.querySelector('.pgn__spinner')).toBeInTheDocument();
     });
 
+    it('renders loading spinner while unit content is loading', () => {
+      const { container } = editorRender(
+        <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
+        { initialState: baseState },
+      );
+
+      expect(screen.getByTestId('editor-container')).toBeInTheDocument();
+      expect(container.querySelector('.pgn__spinner')).toBeInTheDocument();
+      expect(screen.queryByText('Content not found')).not.toBeInTheDocument();
+    });
+
     it('renders editor form when block is finished', () => {
       editorRender(
         <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
@@ -219,6 +243,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               videos: [{ id: 'video-1', display_name: 'Video 1' }],
               problems: [{ id: 'problem-1', display_name: 'Problem 1' }],
             },
@@ -239,6 +264,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               videos: [
                 { id: 'video-1', display_name: 'Intro Video' },
                 { id: 'video-2', display_name: 'Lecture Video' },
@@ -261,6 +287,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               videos: [{ id: 'video-1', display_name: 'Video 1' }],
               problems: [
                 { id: 'problem-1', display_name: 'Quiz Question 1' },
@@ -278,7 +305,15 @@ describe('InVideoQuizEditor', () => {
     it('adds a quiz item when Add problem button is clicked', () => {
       const { container } = editorRender(
         <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
-        { initialState: baseState },
+        {
+          initialState: {
+            ...baseState,
+            inVideoQuiz: {
+              ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
+            },
+          },
+        },
       );
 
       const initialRows = container.querySelectorAll('.quiz-item-row').length;
@@ -290,7 +325,15 @@ describe('InVideoQuizEditor', () => {
     it('removes a quiz item when delete button is clicked', () => {
       const { container } = editorRender(
         <ConnectedInVideoQuizEditor onClose={jest.fn()} />,
-        { initialState: baseState },
+        {
+          initialState: {
+            ...baseState,
+            inVideoQuiz: {
+              ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
+            },
+          },
+        },
       );
 
       expect(container.querySelectorAll('.quiz-item-row').length).toBe(1);
@@ -316,6 +359,7 @@ describe('InVideoQuizEditor', () => {
             ...baseState,
             inVideoQuiz: {
               ...baseState.inVideoQuiz,
+              unitContentLoaded: true,
               selectedVideo: 'video-1',
               videos: [{ id: 'video-1', display_name: 'Video 1' }],
               problems: [

--- a/src/editors/data/redux/inVideoQuiz/reducers.js
+++ b/src/editors/data/redux/inVideoQuiz/reducers.js
@@ -7,6 +7,7 @@ const initialState = {
   selectedVideo: null,
   videos: [],
   problems: [],
+  unitContentLoaded: false,
   quizItems: [
     {
       id: generateId(),
@@ -34,6 +35,10 @@ const inVideoQuiz = createSlice({
     setProblems: (state, { payload }) => ({
       ...state,
       problems: payload,
+    }),
+    setUnitContentLoaded: (state, { payload }) => ({
+      ...state,
+      unitContentLoaded: payload,
     }),
     setQuizItems: (state, { payload }) => ({
       ...state,

--- a/src/editors/data/redux/inVideoQuiz/selectors.js
+++ b/src/editors/data/redux/inVideoQuiz/selectors.js
@@ -11,6 +11,7 @@ export const simpleSelectors = {
   problems: mkSimpleSelector(data => data.problems),
   quizItems: mkSimpleSelector(data => data.quizItems),
   isDirty: mkSimpleSelector(data => data.isDirty),
+  unitContentLoaded: mkSimpleSelector(data => data.unitContentLoaded),
   completeState: mkSimpleSelector(data => data),
 };
 

--- a/src/editors/data/redux/thunkActions/inVideoQuiz.js
+++ b/src/editors/data/redux/thunkActions/inVideoQuiz.js
@@ -23,6 +23,138 @@ const extractBlockId = (fullBlockId) => {
   return parts[parts.length - 1];
 };
 
+const generateQuizItemId = () => `problem-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+
+/** Internal map key for legacy global MM:SS jump-back values. */
+export const GLOBAL_JUMP_BACK_KEY = 'globalJumpBack';
+
+/**
+ * Normalize timemap values that may be a single problem id or an array of ids.
+ * @param {string|string[]} value
+ * @returns {string[]}
+ */
+export const normalizeProblemIds = (value) => {
+  if (Array.isArray(value)) {
+    return value.filter(Boolean);
+  }
+  return value ? [value] : [];
+};
+
+/**
+ * Normalize jump-back field from studio/API into a lookup map.
+ * Supports legacy global MM:SS string, time-keyed map, and per-problem map.
+ */
+export const normalizeJumpBackField = (jumpBack) => {
+  if (!jumpBack) {
+    return {};
+  }
+  if (typeof jumpBack === 'string') {
+    const trimmed = jumpBack.trim();
+    if (!trimmed) {
+      return {};
+    }
+    if (trimmed.charAt(0) === '{') {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (typeof parsed === 'string') {
+          return { [GLOBAL_JUMP_BACK_KEY]: parsed };
+        }
+        return typeof parsed === 'object' && parsed !== null ? parsed : {};
+      } catch (error) {
+        return {};
+      }
+    }
+    return { [GLOBAL_JUMP_BACK_KEY]: trimmed };
+  }
+  if (typeof jumpBack === 'object') {
+    return jumpBack;
+  }
+  return {};
+};
+
+/**
+ * Resolve jump-back for a quiz item row from normalized jump-back data.
+ */
+export const resolveQuizItemJumpBack = (jumpBackMap, problemId, time) => {
+  if (!jumpBackMap || typeof jumpBackMap !== 'object') {
+    return '';
+  }
+  return jumpBackMap[problemId] || jumpBackMap[time] || jumpBackMap[GLOBAL_JUMP_BACK_KEY] || '';
+};
+
+/**
+ * Expand timemap JSON into editor quiz item rows.
+ * Supports legacy {"1:30": "id1"} and multi-problem {"1:30": ["id1", "id2"]}.
+ */
+export const expandTimemapToQuizItems = (timemap, jumpBack = {}) => {
+  const jumpBackMap = normalizeJumpBackField(jumpBack);
+  return Object.entries(timemap).flatMap(([time, problemValue]) => (
+    normalizeProblemIds(problemValue).map((problemId) => ({
+      id: generateQuizItemId(),
+      problemId,
+      time,
+      jumpBack: resolveQuizItemJumpBack(jumpBackMap, problemId, time),
+    }))
+  ));
+};
+
+/**
+ * Group quiz items into timemap JSON for save.
+ * Single problems stay as strings; multiple problems at one time become arrays.
+ */
+export const buildTimemapFromQuizItems = (quizItems) => {
+  const groups = quizItems.reduce((acc, item) => {
+    if (item.problemId && item.time) {
+      if (!acc[item.time]) {
+        acc[item.time] = [];
+      }
+      acc[item.time].push(item.problemId);
+    }
+    return acc;
+  }, {});
+
+  return Object.entries(groups).reduce((acc, [time, problemIds]) => {
+    acc[time] = problemIds.length === 1 ? problemIds[0] : problemIds;
+    return acc;
+  }, {});
+};
+
+/**
+ * Build jump-back map keyed by problem id so multiple problems sharing the same
+ * timestamp can each keep their own jump-back value.
+ */
+export const buildJumpBackFromQuizItems = (quizItems) => (
+  quizItems.reduce((acc, item) => {
+    if (item.problemId && item.jumpBack) {
+      acc[item.problemId] = item.jumpBack;
+    }
+    return acc;
+  }, {})
+);
+
+/**
+ * Parse jump_back textarea value from studio_view HTML.
+ * Supports JSON maps and legacy plain MM:SS strings.
+ */
+export const parseJumpBackField = (value) => {
+  if (!value) {
+    return {};
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === 'string') {
+      return normalizeJumpBackField(parsed);
+    }
+    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+  } catch (error) {
+    return normalizeJumpBackField(trimmed);
+  }
+};
+
 /**
  * Parse studio_view HTML response to extract field values
  * @param {string} html - The HTML response from studio_view API
@@ -61,14 +193,8 @@ const parseStudioViewHtml = (html) => {
   }
 
   if (jumpBackTextarea && jumpBackTextarea.value) {
-    try {
-      const decodedValue = decodeStudioValue(jumpBackTextarea.value);
-      jumpBack = JSON.parse(decodedValue);
-    } catch (error) {
-      logError('Failed to parse jump back data', error);
-      // Return empty jumpBack on parse error to prevent app crash
-      jumpBack = {};
-    }
+    const decodedValue = decodeStudioValue(jumpBackTextarea.value);
+    jumpBack = parseJumpBackField(decodedValue);
   }
 
   return { videoId, timemap, jumpBack };
@@ -124,15 +250,10 @@ export const loadInVideoQuizSettings = () => (dispatch) => {
                 dispatch(actions.inVideoQuiz.setSelectedVideo(videoId));
               }
 
-              // Parse timemap and populate quiz items
-              // timemap format: {"5": "problemId1", "120": "problemId2"}
-              // Convert to quizItems format
-              const quizItems = Object.entries(timemap).map(([time, problemId]) => ({
-                id: `problem-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
-                problemId,
-                time,
-                jumpBack: (jumpBack && jumpBack[time]) || '00:00',
-              }));
+              // Parse timemap and populate quiz items.
+              // Legacy: {"1:30": "problemId1"}
+              // Multi-problem: {"1:30": ["problemId1", "problemId2"]}
+              const quizItems = expandTimemapToQuizItems(timemap, jumpBack);
 
               if (quizItems.length > 0) {
                 dispatch(actions.inVideoQuiz.setQuizItems(quizItems));
@@ -181,21 +302,8 @@ export const saveInVideoQuizSettings = ({ onSuccess, onFailure } = {}) => (dispa
   const studioEndpointUrl = selectors.app.studioEndpointUrl(state);
   const displayName = selectors.app.blockTitle(state) || '';
 
-  // Convert quizItems array to timemap object
-  // Format: {"5": "problemId1", "120": "problemId2"}
-  const timemapObject = quizItems.reduce((acc, item) => {
-    if (item.problemId && item.time) {
-      acc[item.time] = item.problemId;
-    }
-    return acc;
-  }, {});
-
-  const jumpBackObject = quizItems.reduce((acc, item) => {
-    if (item.problemId && item.time && item.jumpBack) {
-      acc[item.time] = item.jumpBack;
-    }
-    return acc;
-  }, {});
+  const timemapObject = buildTimemapFromQuizItems(quizItems);
+  const jumpBackObject = buildJumpBackFromQuizItems(quizItems);
 
   // Convert timemap object to JSON string
   const timemapString = JSON.stringify(timemapObject);

--- a/src/editors/data/redux/thunkActions/inVideoQuiz.js
+++ b/src/editors/data/redux/thunkActions/inVideoQuiz.js
@@ -216,6 +216,7 @@ export const loadInVideoQuizSettings = () => (dispatch) => {
 
           if (!unitAncestor) {
             dispatch(actions.inVideoQuiz.setDirty(false));
+            dispatch(actions.inVideoQuiz.setUnitContentLoaded(true));
             dispatch(actions.requests.completeRequest({
               requestKey: RequestKeys.fetchBlock,
               response: { data: {} },
@@ -260,12 +261,14 @@ export const loadInVideoQuizSettings = () => (dispatch) => {
               }
 
               dispatch(actions.inVideoQuiz.setDirty(false));
+              dispatch(actions.inVideoQuiz.setUnitContentLoaded(true));
               dispatch(actions.requests.completeRequest({
                 requestKey: RequestKeys.fetchBlock,
                 response: { data },
               }));
             })
             .catch((error) => {
+              dispatch(actions.inVideoQuiz.setUnitContentLoaded(true));
               dispatch(actions.requests.failRequest({
                 requestKey: RequestKeys.fetchBlock,
                 error,
@@ -273,6 +276,7 @@ export const loadInVideoQuizSettings = () => (dispatch) => {
             });
         },
         onFailure: (error) => {
+          dispatch(actions.inVideoQuiz.setUnitContentLoaded(true));
           dispatch(actions.requests.failRequest({
             requestKey: RequestKeys.fetchBlock,
             error,
@@ -281,6 +285,7 @@ export const loadInVideoQuizSettings = () => (dispatch) => {
       }));
     },
     onFailure: (error) => {
+      dispatch(actions.inVideoQuiz.setUnitContentLoaded(true));
       dispatch(actions.requests.failRequest({
         requestKey: RequestKeys.fetchBlock,
         error,

--- a/src/editors/data/redux/thunkActions/inVideoQuiz.test.js
+++ b/src/editors/data/redux/thunkActions/inVideoQuiz.test.js
@@ -1,0 +1,165 @@
+import {
+  normalizeProblemIds,
+  normalizeJumpBackField,
+  resolveQuizItemJumpBack,
+  parseJumpBackField,
+  expandTimemapToQuizItems,
+  buildTimemapFromQuizItems,
+  buildJumpBackFromQuizItems,
+  GLOBAL_JUMP_BACK_KEY,
+} from './inVideoQuiz';
+
+describe('inVideoQuiz timemap helpers', () => {
+  describe('normalizeProblemIds', () => {
+    it('returns array for array input', () => {
+      expect(normalizeProblemIds(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('wraps string in array', () => {
+      expect(normalizeProblemIds('problem-1')).toEqual(['problem-1']);
+    });
+
+    it('returns empty array for falsy input', () => {
+      expect(normalizeProblemIds('')).toEqual([]);
+      expect(normalizeProblemIds(null)).toEqual([]);
+    });
+  });
+
+  describe('expandTimemapToQuizItems', () => {
+    it('expands legacy single-problem timemap', () => {
+      const items = expandTimemapToQuizItems({ '1:30': 'problem-1' }, { '1:30': '0:45' });
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({
+        problemId: 'problem-1',
+        time: '1:30',
+        jumpBack: '0:45',
+      });
+    });
+
+    it('expands multi-problem timemap into separate rows', () => {
+      const items = expandTimemapToQuizItems({
+        '1:30': ['problem-1', 'problem-2'],
+      });
+      expect(items).toHaveLength(2);
+      expect(items[0].problemId).toBe('problem-1');
+      expect(items[1].problemId).toBe('problem-2');
+      expect(items[0].time).toBe('1:30');
+      expect(items[1].time).toBe('1:30');
+    });
+
+    it('assigns per-problem jump back for problems at the same timestamp', () => {
+      const items = expandTimemapToQuizItems(
+        { '1:30': ['problem-1', 'problem-2'] },
+        { 'problem-1': '1:29', 'problem-2': '1:35' },
+      );
+      expect(items).toHaveLength(2);
+      expect(items[0].jumpBack).toBe('1:29');
+      expect(items[1].jumpBack).toBe('1:35');
+    });
+
+    it('falls back to legacy time-keyed jump back', () => {
+      const items = expandTimemapToQuizItems(
+        { '1:30': 'problem-1' },
+        { '1:30': '1:00' },
+      );
+      expect(items[0].jumpBack).toBe('1:00');
+    });
+
+    it('applies legacy global jump back string to every problem row', () => {
+      const items = expandTimemapToQuizItems(
+        { '1:30': ['problem-1', 'problem-2'] },
+        '1:29',
+      );
+      expect(items[0].jumpBack).toBe('1:29');
+      expect(items[1].jumpBack).toBe('1:29');
+    });
+  });
+
+  describe('normalizeJumpBackField', () => {
+    it('wraps legacy global MM:SS string', () => {
+      expect(normalizeJumpBackField('1:29')).toEqual({ [GLOBAL_JUMP_BACK_KEY]: '1:29' });
+    });
+
+    it('returns object maps unchanged', () => {
+      expect(normalizeJumpBackField({ 'problem-1': '1:29' })).toEqual({
+        'problem-1': '1:29',
+      });
+    });
+  });
+
+  describe('resolveQuizItemJumpBack', () => {
+    it('prefers per-problem value over time and default', () => {
+      const map = { 'problem-1': '1:29', '1:30': '1:00', [GLOBAL_JUMP_BACK_KEY]: '0:30' };
+      expect(resolveQuizItemJumpBack(map, 'problem-1', '1:30')).toBe('1:29');
+    });
+
+    it('falls back to time-keyed legacy value', () => {
+      expect(resolveQuizItemJumpBack({ '1:30': '1:00' }, 'problem-1', '1:30')).toBe('1:00');
+    });
+
+    it('falls back to global default', () => {
+      expect(resolveQuizItemJumpBack({ [GLOBAL_JUMP_BACK_KEY]: '0:45' }, 'problem-1', '1:30')).toBe('0:45');
+    });
+  });
+
+  describe('parseJumpBackField', () => {
+    it('parses per-problem JSON map', () => {
+      expect(parseJumpBackField('{"problem-1":"1:29","problem-2":"1:45"}')).toEqual({
+        'problem-1': '1:29',
+        'problem-2': '1:45',
+      });
+    });
+
+    it('parses legacy plain MM:SS string', () => {
+      expect(parseJumpBackField('1:29')).toEqual({ [GLOBAL_JUMP_BACK_KEY]: '1:29' });
+    });
+
+    it('parses legacy time-keyed JSON map', () => {
+      expect(parseJumpBackField('{"1:30":"1:29"}')).toEqual({ '1:30': '1:29' });
+    });
+  });
+
+  describe('buildTimemapFromQuizItems', () => {
+    it('uses string value for single problem at a timestamp', () => {
+      const timemap = buildTimemapFromQuizItems([
+        { problemId: 'problem-1', time: '1:30' },
+        { problemId: 'problem-2', time: '2:00' },
+      ]);
+      expect(timemap).toEqual({
+        '1:30': 'problem-1',
+        '2:00': 'problem-2',
+      });
+    });
+
+    it('uses array value for multiple problems at the same timestamp', () => {
+      const timemap = buildTimemapFromQuizItems([
+        { problemId: 'problem-1', time: '1:30' },
+        { problemId: 'problem-2', time: '1:30' },
+      ]);
+      expect(timemap).toEqual({
+        '1:30': ['problem-1', 'problem-2'],
+      });
+    });
+  });
+
+  describe('buildJumpBackFromQuizItems', () => {
+    it('stores a jump back value per problem, even at the same timestamp', () => {
+      const jumpBack = buildJumpBackFromQuizItems([
+        { problemId: 'problem-1', time: '1:30', jumpBack: '0:30' },
+        { problemId: 'problem-2', time: '1:30', jumpBack: '0:45' },
+      ]);
+      expect(jumpBack).toEqual({
+        'problem-1': '0:30',
+        'problem-2': '0:45',
+      });
+    });
+
+    it('omits problems without a jump back value', () => {
+      const jumpBack = buildJumpBackFromQuizItems([
+        { problemId: 'problem-1', time: '1:30', jumpBack: '0:30' },
+        { problemId: 'problem-2', time: '1:30', jumpBack: '' },
+      ]);
+      expect(jumpBack).toEqual({ 'problem-1': '0:30' });
+    });
+  });
+});


### PR DESCRIPTION
- Removed duplicate timestamp validation from InVideoQuizEditor, allowing multiple problems to share the same timestamp.
- Updated quiz item handling in the Redux thunk actions to support expanded timemap formats, including legacy and multi-problem structures.
- Introduced new utility functions for normalizing problem IDs and jump-back fields, improving code organization and readability.
- Added comprehensive unit tests for new and existing functionality to ensure robustness and correctness.
---
# Support ticket: 
- https://2u-internal.atlassian.net/browse/LP-242
---
### Summary
Updates the In-Video Quiz editor MFE to configure multiple problems at the same timestamp, with per-problem jump-back values. Removes duplicate-time validation and adds timemap/jump-back helpers with legacy data support on load and save.

### Changes

**Editor (`InVideoQuizEditor/index.jsx`)**
- Remove duplicate-timestamp validation so multiple problems can share the same time (e.g. both at `01:30`)
- Save/load round-trip via updated thunk helpers

**Data layer (`inVideoQuiz.js`)**
- `normalizeProblemIds()` — handle string or array timemap values
- `expandTimemapToQuizItems()` — load legacy + multi-problem timemaps into editor rows
- `buildTimemapFromQuizItems()` — save single string or array per timestamp
- `buildJumpBackFromQuizItems()` — save jump-back keyed by **problem ID**
- `normalizeJumpBackField()` / `resolveQuizItemJumpBack()` — legacy global MM:SS, time-keyed, and per-problem maps
- `parseJumpBackField()` — parse legacy plain jump-back strings from studio_view HTML

**Tests**
- New `inVideoQuiz.test.js` — **19 tests** for timemap/jump-back helpers
- `InVideoQuizEditor/index.test.jsx` — save allowed with duplicate timestamps

### Supported data formats

| Format | Load | Save |
|--------|------|------|
| Single problem per time | `{"1:30": "id1"}` | Same |
| Multiple problems per time | `{"1:30": ["id1", "id2"]}` | Same |
| Legacy time-keyed jump-back | `{"1:30": "1:29"}` | Per-problem on re-save |
| Per-problem jump-back | `{"id1": "1:29", "id2": "1:45"}` | Same |

### Test plan

- [x] `npm test -- inVideoQuiz` passes
- [x] `npm test -- InVideoQuizEditor` passes
- [x] Studio: add 2 problems at `01:30` with different jump-backs → Save succeeds
- [x] Reopen editor → both problems and jump-back values persist
- [x] Legacy course (single problem, time-keyed jump-back) loads correctly in editor
- [x] End-to-end with LMS: sequential quiz + jump-back after last problem
