### PR TITLE
feat(release-notes): enhance unsubscribe functionality and user exper…

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,9 @@
 import {
   APP_INIT_ERROR, APP_READY, subscribe, initialize, mergeConfig, getConfig, getPath,
 } from '@edx/frontend-platform';
+import {
+  ensureAuthenticatedUser, fetchAuthenticatedUser, getAuthenticatedUser, hydrateAuthenticatedUser,
+} from '@edx/frontend-platform/auth';
 import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
 import React, { StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -47,6 +50,11 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+const isReleaseNoteUnsubscribePath = () => {
+  const normalizedPath = global.location.pathname.replace(/\/$/, '');
+  return normalizedPath.endsWith('/release-notes/unsubscribe');
+};
 
 const App = () => {
   useEffect(() => {
@@ -188,6 +196,19 @@ initialize({
         ENABLE_RELEASE_NOTES: process.env.ENABLE_RELEASE_NOTES || 'false',
         ENABLE_RELEASE_NOTES_BANNER: process.env.ENABLE_RELEASE_NOTES_BANNER || 'false',
       }, 'CourseAuthoringConfig');
+    },
+    auth: async (requireUser, hydrateUser) => {
+      if (isReleaseNoteUnsubscribePath()) {
+        await fetchAuthenticatedUser();
+      } else if (requireUser) {
+        await ensureAuthenticatedUser(globalThis.location.href);
+      } else {
+        await fetchAuthenticatedUser();
+      }
+
+      if (hydrateUser && getAuthenticatedUser() !== null) {
+        hydrateAuthenticatedUser();
+      }
     },
   },
   messages,

--- a/src/release-notes/data/api.js
+++ b/src/release-notes/data/api.js
@@ -1,5 +1,5 @@
 import { getConfig, camelCaseObject } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getAuthenticatedHttpClient, getHttpClient } from '@edx/frontend-platform/auth';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
@@ -27,7 +27,7 @@ export async function deleteReleaseNote(id) {
   return camelCaseObject(data);
 }
 
-export async function unsubscribeFromReleaseNoteEmails() {
-  const { data } = await getAuthenticatedHttpClient().get(getUnsubscribeApiUrl());
+export async function unsubscribeFromReleaseNoteEmails(token) {
+  const { data } = await getHttpClient().post(getUnsubscribeApiUrl(), { token });
   return camelCaseObject(data);
 }

--- a/src/release-notes/data/api.test.js
+++ b/src/release-notes/data/api.test.js
@@ -1,5 +1,5 @@
 import { getConfig } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getAuthenticatedHttpClient, getHttpClient } from '@edx/frontend-platform/auth';
 import MockAdapter from 'axios-mock-adapter';
 
 import { initializeMocks } from '../../testUtils';
@@ -58,11 +58,13 @@ describe('release-notes api', () => {
     await expect(getReleaseNotes()).rejects.toBeTruthy();
   });
 
-  test('unsubscribeFromReleaseNoteEmails issues authenticated GET', async () => {
+  test('unsubscribeFromReleaseNoteEmails posts token without authentication', async () => {
     const expectedUrl = new URL('/api/release_notes/v1/email/unsubscribe/', getConfig().STUDIO_BASE_URL).href;
-    mock.onGet(expectedUrl).reply(200, { message: 'unsubscribed' });
-    const res = await unsubscribeFromReleaseNoteEmails();
+    const unauthenticatedMock = new MockAdapter(getHttpClient());
+    unauthenticatedMock.onPost(expectedUrl).reply(200, { message: 'unsubscribed' });
+    const res = await unsubscribeFromReleaseNoteEmails('signed-token');
     expect(res.message).toBe('unsubscribed');
-    expect(mock.history.get[0].url).toBe(expectedUrl);
+    expect(unauthenticatedMock.history.post[0].url).toBe(expectedUrl);
+    expect(JSON.parse(unauthenticatedMock.history.post[0].data)).toEqual({ token: 'signed-token' });
   });
 });

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.jsx
@@ -1,20 +1,28 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Alert, Button, Card, Container, Spinner,
 } from '@openedx/paragon';
 import { Info, CheckCircle, Email } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { useSearchParams } from 'react-router-dom';
 import { unsubscribeFromReleaseNoteEmails } from '../data/api';
 import messages from './messages';
 
 const ReleaseNoteUnsubscribe = () => {
   const intl = useIntl();
-  const [status, setStatus] = useState('idle'); // idle, loading, success, error
+  const [searchParams] = useSearchParams();
+  const token = useMemo(() => searchParams.get('token'), [searchParams]);
+  const [status, setStatus] = useState(token ? 'idle' : 'invalid');
 
   const handleUnsubscribe = () => {
+    if (!token) {
+      setStatus('invalid');
+      return;
+    }
+
     setStatus('loading');
 
-    unsubscribeFromReleaseNoteEmails()
+    unsubscribeFromReleaseNoteEmails(token)
       .then(() => {
         setStatus('success');
       })
@@ -25,6 +33,12 @@ const ReleaseNoteUnsubscribe = () => {
 
   return (
     <Container size="sm" className="d-flex align-items-center justify-content-center py-5">
+      {status === 'invalid' && (
+        <Alert variant="danger" icon={Info}>
+          <Alert.Heading>{intl.formatMessage(messages.unsubscribeInvalidTitle)}</Alert.Heading>
+          <p className="mb-0">{intl.formatMessage(messages.unsubscribeInvalid)}</p>
+        </Alert>
+      )}
       {status === 'idle' && (
         <Card className="text-center shadow-sm" style={{ maxWidth: '480px' }}>
           <Card.Section className="p-4">

--- a/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
+++ b/src/release-notes/unsubscribe/ReleaseNoteUnsubscribe.test.jsx
@@ -7,13 +7,27 @@ import ReleaseNoteUnsubscribe from './ReleaseNoteUnsubscribe';
 import messages from './messages';
 import * as api from '../data/api';
 
+const renderUnsubscribePage = (search = '') => render(
+  <ReleaseNoteUnsubscribe />,
+  {
+    path: '/release-notes/unsubscribe',
+    routerProps: { initialEntries: [`/release-notes/unsubscribe${search}`] },
+  },
+);
+
 describe('ReleaseNoteUnsubscribe', () => {
   beforeEach(() => {
     initializeMocks();
   });
 
-  test('renders the idle confirmation state', () => {
-    render(<ReleaseNoteUnsubscribe />);
+  test('renders invalid state when token is missing', () => {
+    renderUnsubscribePage();
+    expect(screen.getByText(messages.unsubscribeInvalidTitle.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.unsubscribeInvalid.defaultMessage)).toBeInTheDocument();
+  });
+
+  test('renders the idle confirmation state when token is present', () => {
+    renderUnsubscribePage('?token=signed-token');
     expect(screen.getByText(messages.unsubscribeTitle.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.unsubscribeConfirmation.defaultMessage)).toBeInTheDocument();
     expect(
@@ -21,21 +35,21 @@ describe('ReleaseNoteUnsubscribe', () => {
     ).toBeInTheDocument();
   });
 
-  test('calls unsubscribeFromReleaseNoteEmails and shows success state on success', async () => {
+  test('calls unsubscribeFromReleaseNoteEmails with token and shows success state on success', async () => {
     const spy = jest.spyOn(api, 'unsubscribeFromReleaseNoteEmails').mockResolvedValue({ message: 'ok' });
-    render(<ReleaseNoteUnsubscribe />);
+    renderUnsubscribePage('?token=signed-token');
 
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
 
     await waitFor(() => {
       expect(screen.getByText(messages.unsubscribeSuccessTitle.defaultMessage)).toBeInTheDocument();
     });
-    expect(spy).toHaveBeenCalledWith();
+    expect(spy).toHaveBeenCalledWith('signed-token');
   });
 
   test('shows error state and allows retry on failure', async () => {
     const spy = jest.spyOn(api, 'unsubscribeFromReleaseNoteEmails').mockRejectedValue(new Error('boom'));
-    render(<ReleaseNoteUnsubscribe />);
+    renderUnsubscribePage('?token=signed-token');
 
     fireEvent.click(screen.getByRole('button', { name: messages.unsubscribeButton.defaultMessage }));
 

--- a/src/release-notes/unsubscribe/messages.js
+++ b/src/release-notes/unsubscribe/messages.js
@@ -35,7 +35,15 @@ const messages = defineMessages({
   },
   unsubscribeError: {
     id: 'release-notes.unsubscribe.error',
-    defaultMessage: 'We were unable to process your unsubscribe request. Please sign in with the account that received the email and try again.',
+    defaultMessage: 'We were unable to process your unsubscribe request. Please use the unsubscribe link from your Release Notes email and try again.',
+  },
+  unsubscribeInvalidTitle: {
+    id: 'release-notes.unsubscribe.invalid.title',
+    defaultMessage: 'Invalid Unsubscribe Link',
+  },
+  unsubscribeInvalid: {
+    id: 'release-notes.unsubscribe.invalid',
+    defaultMessage: 'This unsubscribe link is invalid or incomplete. Please open the unsubscribe link from your Release Notes email.',
   },
   unsubscribeRetry: {
     id: 'release-notes.unsubscribe.retry',


### PR DESCRIPTION
## Summary

Enable **token-based, login-free unsubscribe** for Release Notes email notifications.

Previously, the unsubscribe page at `/release-notes/unsubscribe` required Studio login and called an authenticated GET endpoint. Users clicking the link from email were redirected to login, which blocked one-click unsubscribe.

This PR updates the flow so users can unsubscribe using a signed token from their email, without signing in.

### Changes

- **`ReleaseNoteUnsubscribe`** reads `?token=` from the URL and shows:
  - Confirmation UI when a token is present
  - Invalid-link error when the token is missing
- **`unsubscribeFromReleaseNoteEmails(token)`** sends an unauthenticated `POST` to `/api/release_notes/v1/email/unsubscribe/` with `{ token }` via `getHttpClient()` (replaces authenticated GET)
- **`index.jsx`** adds a custom auth handler so `/release-notes/unsubscribe` skips the login redirect while the rest of the MFE still requires authentication
- **i18n** adds invalid-link messages and updates error copy to reference the email link instead of signing in

### User flow

1. User receives a Release Notes digest email with a link like:
   `{COURSE_AUTHORING_MICROFRONTEND_URL}/release-notes/unsubscribe?token=<signed-token>`
2. User opens the link — no login required
3. User confirms unsubscribe
4. Frontend POSTs the token to the backend; success or error is shown on the page

### Backend dependency

Requires the corresponding `edx-platform` / `release-notes` backend change that:
- Generates per-user signed tokens in digest emails
- Exposes `POST /api/release_notes/v1/email/unsubscribe/` with `{ "token": "..." }`

---

### Test plan

- Open `/release-notes/unsubscribe` without a `token` query param → invalid link message is shown
- Open `/release-notes/unsubscribe?token=<valid-token-from-email>` while logged out → page loads without login redirect
- Click **Unsubscribe** with a valid token → success message; user is excluded from future digest emails
- Click **Unsubscribe** with an invalid/expired token → error message with retry option
- Confirm other Studio routes (e.g. `/home`, `/release-notes`) still require login

---

## Support ticket
- [LP-815](https://2u-internal.atlassian.net/browse/LP-815)