### PR TITLE
fix: contract jsinput html_file asset URLs to /static/ on save (LP-704)

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
@@ -227,6 +227,35 @@ describe('TinyMceEditor hooks', () => {
         const content = module.setAssetToStaticUrl({ editorValue, lmsEndpointUrl });
         expect(content).toEqual('<img src="/static/goku.img"/> <a href="/static/goku.img">testing link</a>');
       });
+      it('returns content with updated jsinput html_file links', () => {
+        const editorValue = `<jsinput html_file="/${baseAssetUrl}@textlog.html" gradefn="getGrade"/>`;
+        const lmsEndpointUrl = getConfig().LMS_BASE_URL;
+        const content = module.setAssetToStaticUrl({ editorValue, lmsEndpointUrl });
+        expect(content).toEqual('<jsinput html_file="/static/textlog.html" gradefn="getGrade"/>');
+      });
+      it('returns content with updated jsinput html_file links when URL is absolute', () => {
+        const lmsEndpointUrl = getConfig().LMS_BASE_URL;
+        const editorValue = `<jsinput html_file="${lmsEndpointUrl}/${baseAssetUrl}@textlog.html" gradefn="getGrade"/>`;
+        const content = module.setAssetToStaticUrl({ editorValue, lmsEndpointUrl });
+        expect(content).toEqual('<jsinput html_file="/static/textlog.html" gradefn="getGrade"/>');
+      });
+      it('returns content with updated jsinput html_file links using encoded quotes', () => {
+        const editorValue = `<jsinput html_file=&quot;/${baseAssetUrl}@textlog.html&quot; gradefn=&quot;getGrade&quot;/>`;
+        const lmsEndpointUrl = getConfig().LMS_BASE_URL;
+        const content = module.setAssetToStaticUrl({ editorValue, lmsEndpointUrl });
+        expect(content).toEqual('<jsinput html_file=&quot;/static/textlog.html&quot; gradefn=&quot;getGrade&quot;/>');
+      });
+      it('does not strip the literal text "undefined" when lmsEndpointUrl is not provided', () => {
+        const editorValue = `<p>value may be undefined</p><img src="/${baseAssetUrl}@soME_ImagE_URl1"/>`;
+        const content = module.setAssetToStaticUrl({ editorValue });
+        expect(content).toEqual('<p>value may be undefined</p><img src="/static/soME_ImagE_URl1"/>');
+      });
+      it('returns content with updated href links using encoded quotes', () => {
+        const editorValue = `<a href=&quot;/${baseAssetUrl}@soMEImagEURl&quot;>testing link</a>`;
+        const lmsEndpointUrl = getConfig().LMS_BASE_URL;
+        const content = module.setAssetToStaticUrl({ editorValue, lmsEndpointUrl });
+        expect(content).toEqual('<a href=&quot;/static/soMEImagEURl&quot;>testing link</a>');
+      });
     });
 
     describe('editorConfig', () => {

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.ts
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.ts
@@ -510,10 +510,13 @@ export const setAssetToStaticUrl = ({ editorValue, lmsEndpointUrl }) => {
 
   // TODO: should probably move this to when the assets are being looped through in the off chance that
   // some of the text in the editor contains the lmsEndpointUrl
-  const regExLmsEndpointUrl = RegExp(lmsEndpointUrl, 'g');
-  let content = editorValue.replace(regExLmsEndpointUrl, '');
+  let content = editorValue;
+  if (lmsEndpointUrl) {
+    const escapedLmsEndpointUrl = lmsEndpointUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    content = content.replace(RegExp(escapedLmsEndpointUrl, 'g'), '');
+  }
 
-  const assetSrcs = typeof content === 'string' ? content.split(/(src="|src=&quot;|href="|href=&quot)/g) : [];
+  const assetSrcs = typeof content === 'string' ? content.split(/(src="|src=&quot;|href="|href=&quot;|html_file="|html_file=&quot;)/g) : [];
   assetSrcs.filter(src => src.startsWith('/asset')).forEach(src => {
     const nameFromEditorSrc = parseAssetName(src);
     const portableUrl = getStaticUrl({ displayName: nameFromEditorSrc });


### PR DESCRIPTION
## Description

Fixes LP-704 (frontend layer): the editor bakes course-pinned absolute asset URLs into JSInput problems on save, breaking them after a course re-run or export/import.

Studio's GET API expands portable `/static/<name>` references into absolute `asset-v1:<Org>+<Course>+<Run>+...` URLs pinned to the current course, and the save path persists whatever the editor posts. `setAssetToStaticUrl` (`src/editors/sharedComponents/TinyMceWidget/hooks.ts`) is the editor's contraction step, but its split regex only recognizes `src=` and `href=` attributes — JSInput's `html_file=` passes through untouched, so the expanded absolute URL gets saved. After a re-run, the URL still points at the *original* course and the problem breaks (this is the failure Harvard reported).

### The fix

- Add `html_file="` / `html_file=&quot;` to the attribute-splitting regex in `setAssetToStaticUrl`, so JSInput asset references are contracted back to `/static/<name>` on save like image/link references already are.
- Fix the pre-existing `href=&quot` token, which was missing its trailing `;`: `&quot;` is the complete HTML entity, so the token matched one character short, left a leading `;` on the next split segment, and `&quot;`-encoded `href` asset URLs were never contracted.
- Guard and escape the `lmsEndpointUrl` host-stripping regex: some call sites (`RawEditor`, `TextEditor`) invoke `setAssetToStaticUrl` without `lmsEndpointUrl`, which previously built `/undefined/g` and silently deleted the literal text "undefined" from saved content; the URL's regex metacharacters (`.`) are now escaped as well.

## Testing

- 5 new tests in `hooks.test.js`: a JSInput `html_file` with an expanded asset URL is rewritten to `/static/<name>` on save (plain-quoted, `&quot;`-encoded, and LMS-absolute `https://<lms>/asset-v1:...` forms); a `&quot;`-encoded `href` asset URL is likewise contracted; and content containing the literal text "undefined" survives a save without `lmsEndpointUrl`.
- Verified on devstack: saving a JSInput problem no longer bakes the course id into `html_file`.

### Screenshots

#### Before
<img width="1635" height="794" alt="Screenshot 2026-07-08 at 1 38 19 PM" src="https://github.com/user-attachments/assets/50719a84-06b8-410f-aed3-357076f63835" />

#### After

<img width="1645" height="833" alt="Screenshot 2026-07-08 at 1 43 05 PM" src="https://github.com/user-attachments/assets/ab6b59ac-f4e6-4284-9e9e-c20888f5a995" />


Companion server-side fix: https://github.com/edx/edx-platform/pull/377
