### PR TITLE
fix: prepend https to URLs starting with www

### DIFF
--- a/src/optimizer-page/scan-results/BrokenLinkTable.tsx
+++ b/src/optimizer-page/scan-results/BrokenLinkTable.tsx
@@ -19,14 +19,23 @@ import {
 } from '../../constants';
 
 const BrokenLinkHref: FC<{ href: string }> = ({ href }) => {
+  const normalizedHref = href.startsWith('www.')
+    ? `https://${href}`
+    : href;
+
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
-    window.open(href, '_blank');
+    window.open(normalizedHref, '_blank');
   };
 
   return (
     <div className="broken-link-container">
-      <a href={href} onClick={handleClick} className="broken-link" rel="noreferrer">
+      <a
+        href={normalizedHref}
+        onClick={handleClick}
+        className="broken-link"
+        rel="noreferrer"
+      >
         {href}
       </a>
     </div>


### PR DESCRIPTION
## Description

This change updates the broken link component to normalize URLs that start with `www.` by automatically prepending `https://` before opening them.

Previously, links such as `www.example.com` were treated as relative URLs by the browser, causing them to open incorrectly. With this change, these links are converted to `https://www.example.com` while preserving the original displayed text.

## Changes
- Detect URLs that start with `www.`
- Prepend `https://` before opening the link
- Keep existing behavior unchanged for `http://` and `https://` URLs

## Testing
- Verified `www.example.com` opens as `https://www.example.com`
- Verified `https://example.com` continues to work as expected
- Verified `http://example.com` continues to work as expected

Jira: https://2u-internal.atlassian.net/browse/LP-931